### PR TITLE
Fix broken images and add logo link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -804,7 +804,8 @@
   },
   "logo": {
     "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg"
+    "dark": "/logo/dark.svg",
+    "href": "https://www.usebruno.com"
   },
   "api": {
     "mdx": {

--- a/license-administrators/license-portal.mdx
+++ b/license-administrators/license-portal.mdx
@@ -15,12 +15,12 @@ If you've been designated as a License Administrator, either through purchasing 
 
 - Navigate to https://license.usebruno.com/ 
 
-<Image src="/images/screenshots/license-management/licenseportalenteremail.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/license-management/licenseportalenteremail.webp)
 
 - Enter your email address and press `continue`
 - Retrieve and enter the OTP (one time password) that was sent to your email
 
-<Image src="/images/screenshots/license-management/licenseportalenterotp.webp" alt="License portal OTP" width={800} height={600} className="rounded mt-4" />
+![License portal OTP](/images/screenshots/license-management/licenseportalenterotp.webp)
 
 - You have now accessed the portal! 
 
@@ -32,7 +32,7 @@ If you've been designated as a License Administrator, either through purchasing 
 - Enter the name and email of the user you'd like to add
 - Click `Create`
 
-<Image src="/images/screenshots/license-management/addsingleuser.webp" alt="Adding a single user" width={800} height={600} className="rounded mt-4" />
+![Adding a single user](/images/screenshots/license-management/addsingleuser.webp)
 
 - The user will automatically receive an email with their license key
 
@@ -46,7 +46,7 @@ If you've been designated as a License Administrator, either through purchasing 
 - Click `Upload`and select your file
 - Click `Add Users`
 
-<Image src="/images/screenshots/license-management/addbulkusers.webp" alt="Add bulk users" width={800} height={600} className="rounded mt-4" />
+![Add bulk users](/images/screenshots/license-management/addbulkusers.webp)
 
 - Users will automatically receive an email with their respective license key
 
@@ -64,7 +64,7 @@ If you've been designated as a License Administrator, either through purchasing 
 - Click `Upload`and select your file
 - Click `Delete Users`
 
-<Image src="/images/screenshots/license-management/deletebulkusers.webp" alt="Add bulk users" width={800} height={600} className="rounded mt-4" />
+![Add bulk users](/images/screenshots/license-management/deletebulkusers.webp)
 
 ## Adding License Administrators
 
@@ -73,11 +73,11 @@ The number of License Administrators you can have associated with your account i
 - Navigate to `Settings`
 - Click on `Admins` page
 
-<Image src="/images/screenshots/license-management/adminpage.webp" alt="Admin page" width={800} height={600} className="rounded mt-4" />
+![Admin page](/images/screenshots/license-management/adminpage.webp)
 
 - Select `Add Admin`
 
-<Image src="/images/screenshots/license-management/addadmin.webp" alt="Add admin" width={800} height={600} className="rounded mt-4" />
+![Add admin](/images/screenshots/license-management/addadmin.webp)
 
 - Enter their name and email
 - Select `Add`
@@ -89,4 +89,4 @@ You can view the type of plan, number of licenses, and subscription dates by:
 - Navigate to `Settings`
 - Select `Billing`
 
-<Image src="/images/screenshots/license-management/billingdetails.webp" alt="Billing details" width={800} height={600} className="rounded mt-4" />
+![Billing details](/images/screenshots/license-management/billingdetails.webp)

--- a/license-administrators/saml-sso/configure-saml-sso-with-entra-id.mdx
+++ b/license-administrators/saml-sso/configure-saml-sso-with-entra-id.mdx
@@ -16,7 +16,7 @@ Before configuring a SAML application in Microsoft Entra ID, first configure SSO
 1. Log in to the [Bruno License Portal](https://license.usebruno.com/)
 2. Navigate to **Settings** → **SSO** in the left sidebar
 
-<Image src="/images/screenshots/sso-scim-management/saml-sso/bruno-sso-settings.webp" alt="Bruno SSO Configuration settings page" width={800} height={200} className="rounded mt-4" />
+![Bruno SSO Configuration settings page](/images/screenshots/sso-scim-management/saml-sso/bruno-sso-settings.webp)
 
 3. Toggle the **Enable SSO** switch on
 
@@ -24,7 +24,7 @@ Before configuring a SAML application in Microsoft Entra ID, first configure SSO
    - **SAML ACS URL**: Copy this URL exactly as shown in Bruno
    - **SP Issuer ID / Entity ID**: Set your own unique identifier (e.g., `bruno-sso`, `bruno-entra`, `your-company-bruno`, etc.)
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-0.webp" alt="Bruno SSO Configuration settings page" width={800} height={200} className="rounded mt-4" />
+![Bruno SSO Configuration settings page](/images/screenshots/sso-scim-management/entra/entra-sso-0.webp)
 
 <Info>
 Keep this page open in a separate tab - you'll return here after configuring Entra ID to complete the Bruno SSO setup.
@@ -41,14 +41,14 @@ Keep this page open in a separate tab - you'll return here after configuring Ent
 5. Select **Integrate any other application you don't find in the gallery (Non-gallery)**
 6. Click **Create**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-1.webp" alt="Select SAML as single sign-on method in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Select SAML as single sign-on method in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-1.webp)
 
 ### Step 2: Select SAML as Single Sign-On Method
 
 1. In the created Enterprise Application, navigate to **Manage** → **Single sign-on** in the left sidebar
 2. Select **SAML** as the single sign-on method
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-2.webp" alt="Select SAML as single sign-on method in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Select SAML as single sign-on method in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-2.webp)
 
 ### Step 3: Configure Basic SAML Configuration
 
@@ -58,7 +58,7 @@ Keep this page open in a separate tab - you'll return here after configuring Ent
    - **Reply URL (Assertion Consumer Service URL)**: Copy and paste the **SAML ACS URL** from the Bruno License Portal
 3. Click **Save**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-3.webp" alt="Configure basic SAML settings in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Configure basic SAML settings in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-3.webp)
 
 <Warning>
 **Critical**: The Entity ID in Entra ID must match EXACTLY what you configured in Bruno's **SP Issuer ID / Entity ID** field. A mismatch will cause authentication failures.
@@ -82,7 +82,7 @@ In the **Attributes & Claims** section:
 
 1. Click **Edit**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-5.webp" alt="Configure attributes and claims in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Configure attributes and claims in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-5.webp)
 
 2. Delete any existing claims that are not on this list
 3. You will now update the claims to match the following:
@@ -102,7 +102,7 @@ This claim is required for user identification. It will be mapped to the user's 
 4. Choose `user.mail` as the attribute
 5. Click **Save**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-6.webp" alt="Configure unique user identifier in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Configure unique user identifier in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-6.webp)
 
 #### Configuring the `roles` claim
 
@@ -119,7 +119,7 @@ On the **Attributes & Claims** page:
      - Choose an existing user attribute like `user.assignedroles`, `user.department`, `user.jobtitle`, or custom attributes
 4. Click **Save**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-7.webp" alt="Configure roles claim in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Configure roles claim in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-7.webp)
 
 **Important**: The role value sent by Entra ID will be mapped to Bruno access levels in the License Portal's SSO Settings. You'll configure which role values correspond to admin or user access in Bruno (see Step 2 in the Bruno configuration section below).
 
@@ -145,7 +145,7 @@ On the **Attributes & Claims** page:
    - **Parameter 2**: `user.surname`
 6. Click **Save**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-8.webp" alt="Configure fullName claim in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Configure fullName claim in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-8.webp)
 
 #### Finalized Attributes & Claims Configuration
 
@@ -154,7 +154,7 @@ Return to the **Attributes & Claims** page and verify the following:
 1. Any other claims that are not shown below have been deleted
 2. The `Unique User Identifier (Name ID)`, `roles`, and `fullName` claims are configured as shown above
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-9.webp" alt="Finalized attributes and claims configuration in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Finalized attributes and claims configuration in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-9.webp)
 
 <Warning>
 **Important**: Both `roles` and `fullName` attributes are required for Bruno SAML SSO to function correctly. The attribute names are case-sensitive and must match the appropriate values configured in Entra ID.
@@ -174,13 +174,13 @@ Return to the **Attributes & Claims** page and verify the following:
 2. In the **Set up 'AppName'** section 4, copy the following value:
    - **Login URL**: Copy this URL
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-10.webp" alt="Copy SSO URL from Entra ID" width={800} height={600} className="rounded mt-4" />
+![Copy SSO URL from Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-10.webp)
 
 3. Return to the [Bruno License Portal](https://license.usebruno.com/) tab you opened [from the earlier configuration](#configure-sso-in-bruno)
 4. Navigate to **Settings** → **SSO** (if not already there)
 5. Under **SAML Configuration** paste the **Login URL** from Entra ID into the **IdP Login URL / SSO URL** field
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-11.webp" alt="Paste SSO URL into Bruno SSO settings" width={800} height={600} className="rounded mt-4" />
+![Paste SSO URL into Bruno SSO settings](/images/screenshots/sso-scim-management/entra/entra-sso-11.webp)
 
 ### Step 2: Add IdP Certificate to Bruno License Portal
 
@@ -189,13 +189,13 @@ Return to the **Attributes & Claims** page and verify the following:
 1. In the **SAML Certificates** section 3:
    - **Certificate (Base64)**: Download the certificate
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-12.webp" alt="Download SAML certificate from Entra ID" width={800} height={600} className="rounded mt-4" />
+![Download SAML certificate from Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-12.webp)
 
 2. Open the downloaded certificate file and copy the contents (include the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` lines)
 3. Return to the Bruno License Portal tab
 4. Under **SAML Configuration** paste the certificate contents into the **IdP Certificate** field
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-10.webp" alt="Paste SAML certificate into Bruno SSO settings" width={800} height={600} className="rounded mt-4" />
+![Paste SAML certificate into Bruno SSO settings](/images/screenshots/sso-scim-management/okta/okta-sso-10.webp)
 
 ### Step 3: Map the role values from Entra ID to Bruno access levels
 
@@ -210,7 +210,7 @@ Return to the **Attributes & Claims** page and verify the following:
    - These values must match what you configured in the `roles` attribute in Entra ID
    - Users with these roles will be able to activate their Bruno licenses with SSO. **They will not have access to the admin panel.**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-11.webp" alt="Configure role mapping in Bruno License Portal" width={800} height={600} className="rounded mt-4" />
+![Configure role mapping in Bruno License Portal](/images/screenshots/sso-scim-management/okta/okta-sso-11.webp)
 
 <Info>
 **How Role Mapping Works:**
@@ -246,7 +246,7 @@ The role value you configured in Entra ID's `roles` claim will be sent in the SA
 1. In your Entra ID Enterprise Application, navigate to **Manage** → **Users and groups** in the left sidebar
 2. Click **Add user/group**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-13.webp" alt="Assign users or groups to Bruno app in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Assign users or groups to Bruno app in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-13.webp)
 
 3. Select the users or groups that should have access to Bruno, if using [App Roles](https://learn.microsoft.com/en-us/entra/external-id/customers/how-to-use-app-roles-customers#app-roles) they can be assigned here
 4. Click **Assign**
@@ -258,7 +258,7 @@ The role value you configured in Entra ID's `roles` claim will be sent in the SA
 3. Click **Login with SSO**
 4. You should be redirected to Entra ID to authenticate
 
-<Image src="/images/screenshots/sso-scim-management/saml-sso/bruno-lic-mgr-loginwsso.webp" alt="Login with SSO in Bruno License Portal" width={800} height={600} className="rounded mt-4" />
+![Login with SSO in Bruno License Portal](/images/screenshots/sso-scim-management/saml-sso/bruno-lic-mgr-loginwsso.webp)
 
 5. If your user is an admin in Bruno and contains the correct role mapping, you should be redirected back to the Bruno License Portal
 

--- a/license-administrators/saml-sso/configure-saml-sso-with-okta.mdx
+++ b/license-administrators/saml-sso/configure-saml-sso-with-okta.mdx
@@ -15,7 +15,7 @@ Before configuring a SAML application in Okta, first configure SSO in Bruno.
 1. Log in to the [Bruno License Portal](https://license.usebruno.com/)
 2. Navigate to **Settings** → **SSO** in the left sidebar
 
-<Image src="/images/screenshots/sso-scim-management/saml-sso/bruno-sso-settings.webp" alt="Bruno SSO Configuration settings page" width={800} height={200} className="rounded mt-4" />
+![Bruno SSO Configuration settings page](/images/screenshots/sso-scim-management/saml-sso/bruno-sso-settings.webp)
 
 3. Toggle the **Enable SSO** switch on
 
@@ -23,7 +23,7 @@ Before configuring a SAML application in Okta, first configure SSO in Bruno.
    - **SAML ACS URL**: Copy this URL exactly as shown in Bruno 
    - **SP Issuer ID / Entity ID**: Set your own unique identifier (e.g., `bruno-sso`, `bruno-okta`, `your-company-bruno`, etc.)
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-4.webp" alt="Bruno SSO Configuration settings page with SAML ACS URL and SP Issuer ID / Entity ID highlighted" width={800} height={200} className="rounded mt-4" />
+![Bruno SSO Configuration settings page with SAML ACS URL and SP Issuer ID / Entity ID highlighted](/images/screenshots/sso-scim-management/okta/okta-sso-4.webp)
 
 <Info>
 Keep this page open in a separate tab - you'll return here after configuring Okta to complete the Bruno SSO setup.
@@ -37,12 +37,12 @@ Keep this page open in a separate tab - you'll return here after configuring Okt
 2. Navigate to **Applications** → **Applications** in the left sidebar
 3. Click **Create App Integration**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-1.webp" alt="Create App Integration in Okta" width={800} height={600} className="rounded mt-4" />
+![Create App Integration in Okta](/images/screenshots/sso-scim-management/okta/okta-swa-1.webp)
 
 4. Select **SAML 2.0** as the sign-in method
 5. Click **Next**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-1.webp" alt="Select SAML 2.0 as sign-in method" width={800} height={600} className="rounded mt-4" />
+![Select SAML 2.0 as sign-in method](/images/screenshots/sso-scim-management/okta/okta-sso-1.webp)
 
 ### Step 2: Configure General Settings
 
@@ -52,7 +52,7 @@ Keep this page open in a separate tab - you'll return here after configuring Okt
    - **App visibility**: Configure based on your organization's preferences
 2. Click **Next**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-2.webp" alt="Configure general settings for Bruno SAML app in Okta" width={800} height={600} className="rounded mt-4" />
+![Configure general settings for Bruno SAML app in Okta](/images/screenshots/sso-scim-management/okta/okta-sso-2.webp)
 
 ### Step 3: Configure SAML Settings
 
@@ -81,7 +81,7 @@ Copy the values from the Bruno SSO settings page and paste them into your SAML c
 
 1. Select **Email** from the **Application username** dropdown
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-3.webp" alt="Configure Audience URI (SP Entity ID) in Okta" width={800} height={600} className="rounded mt-4" />
+![Configure Audience URI (SP Entity ID) in Okta](/images/screenshots/sso-scim-management/okta/okta-sso-3.webp)
 
 ### Step 4: Configure Attribute Statements
 
@@ -122,7 +122,7 @@ The `fullName` attribute can be configured by:
 - Mapping to any existing user property that contains the full name
 </Info>
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-5.webp" alt="Configure attribute statements in Okta showing roles and fullName" width={800} height={600} className="rounded mt-4" />
+![Configure attribute statements in Okta showing roles and fullName](/images/screenshots/sso-scim-management/okta/okta-sso-5.webp)
 
 <Warning>
 **Important**: Both `roles` and `fullName` attributes are required for Bruno SAML SSO to function correctly. The attribute names are case-sensitive and must match exactly as shown.
@@ -142,7 +142,7 @@ The `fullName` attribute can be configured by:
    - Check **This is an internal app that we have created**
 2. Click **Finish**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-6.webp" alt="Complete Okta app setup" width={800} height={600} className="rounded mt-4" />
+![Complete Okta app setup](/images/screenshots/sso-scim-management/okta/okta-sso-6.webp)
 
 ## Finish SSO Configuration in Bruno
 
@@ -155,13 +155,13 @@ The `fullName` attribute can be configured by:
 3. Copy the following values (you'll need these for Bruno configuration):
    - **Sign on URL**: Copy this URL
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-7.webp" alt="Copy SAML metadata from Okta" width={800} height={600} className="rounded mt-4" />
+![Copy SAML metadata from Okta](/images/screenshots/sso-scim-management/okta/okta-sso-7.webp)
 
 4. Return to the Bruno License Portal tab you opened [from the earlier configuration](#configure-sso-in-bruno)
 5. Navigate to **Settings** → **SSO** (if not already there)
 6. Under **SAML Configuration** paste the **Sign on URL** from Okta into the **IdP Login URL / SSO URL** field
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-9.webp" alt="Paste SSO URL into Bruno SSO settings" width={800} height={600} className="rounded mt-4" />
+![Paste SSO URL into Bruno SSO settings](/images/screenshots/sso-scim-management/okta/okta-sso-9.webp)
 
 ### Step 2: Add IdP Certificate to Bruno License Portal
 
@@ -171,13 +171,13 @@ The `fullName` attribute can be configured by:
 2. Click **Generate new certificate**
 3. For the newly generated certificate, click the **Actions** dropdown and select **Download Certificate**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-8.webp" alt="Download SAML certificate from Okta" width={800} height={600} className="rounded mt-4" />
+![Download SAML certificate from Okta](/images/screenshots/sso-scim-management/okta/okta-sso-8.webp)
 
 4. Open the downloaded certificate file and copy the contents (include the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` lines)
 5. Return to the Bruno License Portal tab you opened [from the earlier configuration](#configure-sso-in-bruno)
 6. Under **SAML Configuration** paste the certificate contents into the **IdP Certificate** field
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-10.webp" alt="Paste SAML certificate into Bruno SSO settings" width={800} height={600} className="rounded mt-4" />
+![Paste SAML certificate into Bruno SSO settings](/images/screenshots/sso-scim-management/okta/okta-sso-10.webp)
 
 ### Step 3: Map the role values from Okta to Bruno access levels
 
@@ -191,7 +191,7 @@ The `fullName` attribute can be configured by:
    - Example: `user,Engineering,Developers,QA`
    - These values must match what you configured in the `roles` attribute in Okta
    - Users with these roles will be able to activate their Bruno licenses with SSO. **They will not have access to the admin panel.**
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-11.webp" alt="Configure role mapping in Bruno License Portal" width={800} height={600} className="rounded mt-4" />
+![Configure role mapping in Bruno License Portal](/images/screenshots/sso-scim-management/okta/okta-sso-11.webp)
 
 <Info>
 **How Role Mapping Works:**
@@ -215,7 +215,7 @@ The role value you configured in Okta's `roles` attribute statement will be sent
    - Set the session timeout in seconds (default: 3600 = 1 hour)
 2. Click **Save Configuration** to apply your SAML SSO configuration
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-12.webp" alt="Configure session timeout in Bruno License Portal" width={800} height={600} className="rounded mt-4" />
+![Configure session timeout in Bruno License Portal](/images/screenshots/sso-scim-management/okta/okta-sso-12.webp)
 
 {/* TODO: Add screenshot - bruno-role-mapping.png
      Shows the role mapping configuration in Bruno
@@ -231,7 +231,7 @@ The role value you configured in Okta's `roles` attribute statement will be sent
 3. Select the users or groups that should have access to Bruno
 4. Click **Assign** and **Done**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-13.webp" alt="Assign users or groups to Bruno app in Okta" width={800} height={600} className="rounded mt-4" />
+![Assign users or groups to Bruno app in Okta](/images/screenshots/sso-scim-management/okta/okta-sso-13.webp)
 
 ### Test SSO Login
 
@@ -240,7 +240,7 @@ The role value you configured in Okta's `roles` attribute statement will be sent
 3. Click **Login with SSO**
 4. You should be redirected to Okta to authenticate
 
-<Image src="/images/screenshots/sso-scim-management/saml-sso/bruno-lic-mgr-loginwsso.webp" alt="Login with SSO in Bruno License Portal" width={800} height={600} className="rounded mt-4" />
+![Login with SSO in Bruno License Portal](/images/screenshots/sso-scim-management/saml-sso/bruno-lic-mgr-loginwsso.webp)
 
 5. If your user is an admin in Bruno and contains the correct role mapping, you should be redirected back to the Bruno License Portal
 

--- a/license-administrators/saml-sso/overview.mdx
+++ b/license-administrators/saml-sso/overview.mdx
@@ -158,7 +158,7 @@ In the Bruno License Portal's SSO Settings, you'll find two fields under "Role M
    - Example: `user,Engineering,Developers`
    - Users with these roles have standard access to Bruno
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-sso-11.webp" alt="Bruno SAML SSO role mapping configuration showing Admin Roles and User Roles fields" width={800} height={600} className="rounded mt-4" />
+![Bruno SAML SSO role mapping configuration showing Admin Roles and User Roles fields](/images/screenshots/sso-scim-management/okta/okta-sso-11.webp)
 
 <Info>
 **How Role Mapping Works:**

--- a/license-administrators/scim-provisioning/configure-scim-with-entra-id.mdx
+++ b/license-administrators/scim-provisioning/configure-scim-with-entra-id.mdx
@@ -28,13 +28,13 @@ Microsoft Entra ID queries the Bruno SCIM endpoint every 40 minutes for assigned
    - Select **Integrate any other application you don't find in the gallery (Non-gallery)**
    - Click **Create**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-sso-1.webp" alt="Configure custom application in Entra ID" width={800} height={600} className="rounded mt-4" />
+![Configure custom application in Entra ID](/images/screenshots/sso-scim-management/entra/entra-sso-1.webp)
 
 ## Configure automatic provisioning
 
 1. In your newly created (or existing) Enterprise Application, select **Provisioning** from the left navigation menu
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-scim-3.webp" alt="Select Automatic provisioning mode" width={800} height={600} className="rounded mt-4" />
+![Select Automatic provisioning mode](/images/screenshots/sso-scim-management/entra/entra-scim-3.webp)
 
 2. In the **Provisioning Mode** dropdown, select **Automatic**
 
@@ -42,7 +42,7 @@ Microsoft Entra ID queries the Bruno SCIM endpoint every 40 minutes for assigned
    - **Tenant URL**: `https://license.usebruno.com/scim/v2`
    - **Secret Token**: Enter the SCIM API key you generated in the [prerequisites step](./overview#enabling-scim-provisioning)
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-scim-4.webp" alt="Configure admin credentials" width={800} height={600} className="rounded mt-4" />
+![Configure admin credentials](/images/screenshots/sso-scim-management/entra/entra-scim-4.webp)
 
 4. Click **Test Connection** to verify that Microsoft Entra ID can connect to Bruno's SCIM endpoint
 5. If the test is successful, click **Save** to save the admin credentials
@@ -55,14 +55,14 @@ Attribute mappings control how user data from Microsoft Entra ID is mapped to Br
 
 1. Under the **Mappings** section, click **Provision Microsoft Entra ID Users**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-scim-5.webp" alt="Configure user mappings" width={800} height={600} className="rounded mt-4" />
+![Configure user mappings](/images/screenshots/sso-scim-management/entra/entra-scim-5.webp)
 
 2. Under **Target Object Actions**, ensure the following are enabled:
    - **Create**
    - **Update**
    - **Delete**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-scim-7.webp" alt="Configure attribute mappings" width={800} height={600} className="rounded mt-4" />
+![Configure attribute mappings](/images/screenshots/sso-scim-management/entra/entra-scim-7.webp)
 
 3. Under **Attribute Mappings**, configure the following mappings. **You must remove any existing attribute mappings that are not on this list** to avoid conflicts:
 
@@ -75,7 +75,7 @@ Attribute mappings control how user data from Microsoft Entra ID is mapped to Br
    | `name.givenName` | `givenName` | Direct | No | Always |
    | `name.familyName` | `surname` | Direct | No | Always |
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-scim-8.webp" alt="Configure attribute mappings" width={800} height={600} className="rounded mt-4" />
+![Configure attribute mappings](/images/screenshots/sso-scim-management/entra/entra-scim-8.webp)
 
 <Warning>
 **Important**:
@@ -97,7 +97,7 @@ Attribute mappings control how user data from Microsoft Entra ID is mapped to Br
 
 3. Set **Provisioning Status** to **On**
 
-<Image src="/images/screenshots/sso-scim-management/entra/entra-scim-6.webp" alt="Enable provisioning" width={800} height={600} className="rounded mt-4" />
+![Enable provisioning](/images/screenshots/sso-scim-management/entra/entra-scim-6.webp)
 
 4. Click **Save**
 
@@ -115,7 +115,7 @@ The initial provisioning cycle will begin immediately. Microsoft Entra ID will c
 
 5. Assigned users will receive an email with their **License Key** once the provisioning cycle completes
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-12.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-12.webp)
 
 <Info>
 **Note**: Microsoft Entra ID syncs changes every 40 minutes. For immediate provisioning of specific users, you can use the [on-demand provisioning feature](https://learn.microsoft.com/entra/identity/app-provisioning/provision-on-demand) in Microsoft Entra ID.
@@ -129,7 +129,7 @@ The initial provisioning cycle will begin immediately. Microsoft Entra ID will c
 
 3. The user's license will be deactivated during the next provisioning cycle (within 40 minutes), and they will receive an email notification
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-14.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-14.webp)
 
 <Info>
 **Note**: Microsoft Entra ID syncs changes every 40 minutes. For immediate provisioning of specific users, you can use the [on-demand provisioning feature](https://learn.microsoft.com/entra/identity/app-provisioning/provision-on-demand) in Microsoft Entra ID.

--- a/license-administrators/scim-provisioning/configure-scim-with-okta.mdx
+++ b/license-administrators/scim-provisioning/configure-scim-with-okta.mdx
@@ -17,24 +17,24 @@ This guide will walk you through setting up SCIM (System for Cross-domain Identi
 
 1. As an Okta admin, navigate to **Applications** and click **Create App Integration**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-1.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-1.webp)
 
 2. Select **SWA - Secure Web Authentication** and click **Next**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-2.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-2.webp)
 
 3. On the **Create SWA Integration** page, add the following values and click **Finish**:
    - **App name**: (Unique App Name - e.g. Bruno SCIM Integration)
    - **App's login page URL**: `https://license.usebruno.com/`
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-3.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-3.webp)
 
 ## Configure your Okta App
 
 1. On your newly created application page, select the **General** tab
 2. Under **App Settings**, select **Edit**, and check the **Provisioning** option **SCIM** and click **Save**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-5.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-5.webp)
 
 3. Return to your Okta app, select the **Provisioning** tab, under **SCIM Connection** select **Edit** and configure the following values:
    - **SCIM connector base URL**: `https://license.usebruno.com/scim/v2`
@@ -47,11 +47,11 @@ This guide will walk you through setting up SCIM (System for Cross-domain Identi
    - **Authentication**: set to **HTTP Header**
    - Under **HTTP Header**, for **token**: add the generated API Key value from the [prerequisites step](./overview#enabling-scim-provisioning)
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-7.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-7.webp)
 
 4. Click **Test Connector Configuration**. If successful, a **Connector configured successfully** message dialogue appears.
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-8.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-8.webp)
 
 5. Click **Save** to complete the Provisioning integration.
 
@@ -60,7 +60,7 @@ This guide will walk you through setting up SCIM (System for Cross-domain Identi
    - `Update User Attributes`
    - `Deactivate Users`
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-9.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-9.webp)
 
 Your SCIM integration is now complete. You can now begin [assigning users to Bruno](#assign-people-and-groups-to-bruno-in-okta).
 
@@ -70,20 +70,20 @@ Your SCIM integration is now complete. You can now begin [assigning users to Bru
 
 2. Select **Assign** and either **Assign to People** or **Assign to Groups** to provision Bruno license keys
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-15.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-15.webp)
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-16.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-16.webp)
 
 3. Assigned Users will receive an email with their **License Key**
 
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-12.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-12.webp)
 
 ## Deprovision users from Bruno in Okta
 
 1. Under your created Bruno Application, navigate to the **Assignments** tab
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-13.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-13.webp)
 2. Remove the desired users or groups, their license key(s) will be deactivated and they will receive an email notification
-<Image src="/images/screenshots/sso-scim-management/okta/okta-swa-14.webp" alt="License portal login" width={800} height={600} className="rounded mt-4" />
+![License portal login](/images/screenshots/sso-scim-management/okta/okta-swa-14.webp)
 
 ## Related Resources
 

--- a/license-administrators/scim-provisioning/overview.mdx
+++ b/license-administrators/scim-provisioning/overview.mdx
@@ -44,7 +44,7 @@ You must have Ultimate Edition with SCIM provisioning enabled before you can con
 3. Select **SCIM Provisioning** from the settings page
 4. Toggle **Enable SCIM** to turn it on
 
-<Image src="/images/screenshots/sso-scim-management/bruno-scim/scim-settings-1.webp" alt="Enable SCIM in Bruno license portal" width={800} height={600} className="rounded mt-4" />
+![Enable SCIM in Bruno license portal](/images/screenshots/sso-scim-management/bruno-scim/scim-settings-1.webp)
 
 ### Generating SCIM API Key
 
@@ -52,7 +52,7 @@ You must have Ultimate Edition with SCIM provisioning enabled before you can con
 2. Click **Generate New API Key**
 3. Copy your new API key for later use when configuring your identity provider - this key will not be shown again
 
-<Image src="/images/screenshots/sso-scim-management/bruno-scim/scim-settings-2.webp" alt="Generate SCIM API Key in Bruno license portal" width={800} height={600} className="rounded mt-4" />
+![Generate SCIM API Key in Bruno license portal](/images/screenshots/sso-scim-management/bruno-scim/scim-settings-2.webp)
 
 You can revisit this page to manage your SCIM API keys. The SCIM Base URL and API key will be needed when configuring your identity provider.
 


### PR DESCRIPTION
## Summary
This PR fixes broken images across the license administrator documentation and adds a clickable link to the Bruno logo.

## Changes

### Fixed Broken Images (49 total)
Converted Next.js `<Image>` components to standard Markdown syntax across 6 files:
- **license-administrators/saml-sso/configure-saml-sso-with-okta.mdx** - 16 images
- **license-administrators/saml-sso/configure-saml-sso-with-entra-id.mdx** - 16 images
- **license-administrators/scim-provisioning/configure-scim-with-entra-id.mdx** - 9 images
- **license-administrators/scim-provisioning/configure-scim-with-okta.mdx** - 13 images
- **license-administrators/license-portal.mdx** - 7 images
- **license-administrators/scim-provisioning/overview.mdx** - 2 images
- **license-administrators/saml-sso/overview.mdx** - 1 image

### Added Logo Link
- Added `href` property to logo configuration in `docs.json`
- Logo now redirects to https://www.usebruno.com when clicked

## Why Were Images Broken?

The `<Image>` component is a Next.js/React component that requires an import statement. After migrating from Next.js to Mintlify:
- These components remained in the MDX file- These c im- These components remained in tha - These components remained in the MDX file- These c im- These components remained ## Solution

Converted all instances to standard Markdown syntax which works nativelyConverted all instances to standard Markdown syntax which works nativelyConverted allsplay correctly on affected pages.