### PR TITLE
Add Google Analytics 4 tracking

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -861,6 +861,11 @@
     "suggestEdit": true,
     "raiseIssue": true
   },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-EB5Y7HLTX3"
+    }
+  },
   "redirects": [
     {
       "source": "/introduction",


### PR DESCRIPTION
## Summary

This PR adds Google Analytics 4 (GA4) integration to track visitor behavior and engagement across the documentation site.

## Changes

- Added GA4 configuration to `docs.json` with measurement ID `G-EB5Y7HLTX3`
- Enables tracking of:
  - Page views
  - User engagement
  - Navigation patterns
  - Search queries

## Notes

- Analytics data will be available in Google Analytics 24-48 hours after deployment
- Preview deployments have analytics disabled by default
- Only production traffic at `https://docs.usebruno.com` will be tracked

## Testing

You can verify the integration is working using the [Google Analytics Debugger Chrome extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) after deployment.