### PR TITLE
update res body options flag from js api doc

### DIFF
--- a/testing/script/javascript-reference.mdx
+++ b/testing/script/javascript-reference.mdx
@@ -33,7 +33,7 @@ Here is a complete table for all available methods on the `req` object.
 | req.getHeaders()               | Get all request headers.                                             |
 | req.setHeader(name, value)     | Set a request header by name.                                        |
 | req.setHeaders(headers)        | Set multiple request headers.                                        |
-| req.getBody(options?)          | Get the current request body/payload (supports raw option).          |
+| req.getBody(options?)          | Get the current request body/payload.                                        |
 | req.setBody(body)              | Set the request body/payload.                                        |
 | req.setMaxRedirects(count)     | Set the maximum number of redirects to follow.                       |
 | req.getTimeout()               | Get the current timeout value of the request.                        |
@@ -166,18 +166,10 @@ Below is the API documentation for the methods available on `req`
 ### Body Methods
 
 - **`getBody(options?)`** - Get the current request body/payload.
-  
-  **Parameters:**
-  - `options` (object, optional): Configuration options
-    - `raw` (boolean): When `true`, returns the raw body without any parsing. When `false` or not provided, returns the parsed body (default behavior).
 
-  **Examples:**
+  **Example:**
   ```javascript
-  // Get parsed body (default)
   const body = req.getBody();
-
-  // Get raw body without parsing
-  const rawBody = req.getBody({ raw: true });
   ```
 
 - **`setBody(body)`** - Set the request body/payload.
@@ -280,7 +272,7 @@ Here is a complete table for all available properties and methods on the `res` o
 | res.getStatusText()            | Get the response status text.                                                  |
 | res.getHeader(name)            | Get a specific response header by name.                                        |
 | res.getHeaders()               | Get all response headers.                                                      |
-| res.getBody(options?)          | Get the response body data (supports raw option).                              |
+| res.getBody()          | Get the response body data.                                                  |
 | res.setBody(body)              | Set the response body data.                                                    |
 | res.getResponseTime()          | Get the response time in milliseconds.                                         |
 | res.getUrl()                   | Get the response URL (final URL after redirects).                              |
@@ -350,19 +342,11 @@ Below are the detailed descriptions for properties and methods available on the 
 
 ### Body Methods
 
-- **`getBody(options?)`** - Get the response body data.
-  
-  **Parameters:**
-  - `options` (object, optional): Configuration options
-    - `raw` (boolean): When `true`, returns the raw response body without any parsing. When `false` or not provided, returns the parsed body (default behavior).
+- **`getBody()`** - Get the response body data.
 
-  **Examples:**
+  **Example:**
   ```javascript
-  // Get parsed response data (default)
   let data = res.getBody();
-
-  // Get raw response body without parsing
-  let rawData = res.getBody({ raw: true });
   ```
 
 - **`setBody(body)`** - Set the response body data.

--- a/v2/testing/script/javascript-reference.mdx
+++ b/v2/testing/script/javascript-reference.mdx
@@ -28,7 +28,7 @@ Here is a complete table for all available methods on the `req` object.
 | req.getHeaders()               | Get all request headers.                                             |
 | req.setHeader(name, value)     | Set a request header by name.                                        |
 | req.setHeaders(headers)        | Set multiple request headers.                                        |
-| req.getBody(options?)          | Get the current request body/payload (supports raw option).          |
+| req.getBody(options?)          | Get the current request body/payload.                                        |
 | req.setBody(body)              | Set the request body/payload.                                        |
 | req.setMaxRedirects(count)     | Set the maximum number of redirects to follow.                       |
 | req.getTimeout()               | Get the current timeout value of the request.                        |
@@ -127,18 +127,10 @@ Below is the API documentation for the methods available on `req`
 ### Body Methods
 
 - **`getBody(options?)`** - Get the current request body/payload.
-  
-  **Parameters:**
-  - `options` (object, optional): Configuration options
-    - `raw` (boolean): When `true`, returns the raw body without any parsing. When `false` or not provided, returns the parsed body (default behavior).
 
-  **Examples:**
+  **Example:**
   ```javascript
-  // Get parsed body (default)
   const body = req.getBody();
-
-  // Get raw body without parsing
-  const rawBody = req.getBody({ raw: true });
   ```
 
 - **`setBody(body)`** - Set the request body/payload.
@@ -241,7 +233,7 @@ Here is a complete table for all available properties and methods on the `res` o
 | res.getStatusText()            | Get the response status text.                                                  |
 | res.getHeader(name)            | Get a specific response header by name.                                        |
 | res.getHeaders()               | Get all response headers.                                                      |
-| res.getBody(options?)          | Get the response body data (supports raw option).                              |
+| res.getBody()          | Get the response body data.                                                  |
 | res.setBody(body)              | Set the response body data.                                                    |
 | res.getResponseTime()          | Get the response time in milliseconds.                                         |
 | res.getUrl()                   | Get the response URL (final URL after redirects).                              |
@@ -311,19 +303,11 @@ Below are the detailed descriptions for properties and methods available on the 
 
 ### Body Methods
 
-- **`getBody(options?)`** - Get the response body data.
-  
-  **Parameters:**
-  - `options` (object, optional): Configuration options
-    - `raw` (boolean): When `true`, returns the raw response body without any parsing. When `false` or not provided, returns the parsed body (default behavior).
+- **`getBody()`** - Get the response body data.
 
-  **Examples:**
+  **Example:**
   ```javascript
-  // Get parsed response data (default)
   let data = res.getBody();
-
-  // Get raw response body without parsing
-  let rawData = res.getBody({ raw: true });
   ```
 
 - **`setBody(body)`** - Set the response body data.


### PR DESCRIPTION
- Remove `res.getBody(?options)` API from JS ref document