### PR TITLE
Fix timestamp variable description to seconds

### DIFF
--- a/testing/script/dynamic-variables.mdx
+++ b/testing/script/dynamic-variables.mdx
@@ -91,7 +91,7 @@ Bruno provides a comprehensive set of dynamic variables for generating test data
 | Variable Name | Description | Examples |
 |--------------|-------------|----------|
 | `{{$guid}}` | A random UUID | 550e8400-e29b-41d4-a716-446655440000 |
-| `{{$timestamp}}` | Current timestamp in milliseconds | 1562757107 |
+| `{{$timestamp}}` | Current timestamp in seconds | 1562757107 |
 | `{{$isoTimestamp}}` | Current timestamp in ISO format | 2024-03-20T12:34:56.789Z |
 | `{{$randomUUID}}` | A random UUID | 550e8400-e29b-41d4-a716-446655440000 |
 | `{{$randomNanoId}}` | A random Nano ID | V1StGXR8_Z5jdHi6B5cEn4c8b8w |


### PR DESCRIPTION
Updated the description of the `{{$timestamp}}` variable to specify that it returns the current timestamp in seconds instead of milliseconds, as it does return seconds actually.