### PR TITLE
Add embedded YouTube videos to testing docs

### DIFF
--- a/testing/automate-test/automate-test.mdx
+++ b/testing/automate-test/automate-test.mdx
@@ -7,5 +7,11 @@ The [Bruno CLI](/bru-cli/overview) is a command line utility that allows you to 
 
 Continuous integration and continuous delivery (CI/CD) empower teams to ship software updates rapidly and reliably, maximizing user value without compromising quality. By integrating automated API tests into the build pipeline, you verify that every code change is validated and production-ready.
 
-For more information on the Bruno CLI, go to that [specific section of the documentation](/bru-cli/overview). 
+For more information on the Bruno CLI, go to that [specific section of the documentation](/bru-cli/overview).
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/pke-mOR_tyc"
+  title="Automated Testing in Bruno"
+  allowFullScreen
+/>

--- a/testing/automate-test/data-driven-testing.mdx
+++ b/testing/automate-test/data-driven-testing.mdx
@@ -5,6 +5,13 @@ sidebarTitle: "Data Driven Testing"
 
 The **Collection Runner** feature allows you to iterate over data files, making it easy to automate and manage data-driven requests. Bruno supports both CSV and JSON files for running requests, so you can efficiently run tests or process multiple data inputs.
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/l5LugwPtChk"
+  title="Data Driven Testing in Bruno"
+  allowFullScreen
+/>
+
 ## How request bodies and data files work together
 
 Understanding this avoids the most common confusion with data-driven runs:


### PR DESCRIPTION
## Summary

Adds YouTube video embeds to two testing documentation pages.

## Changes

- **Data Driven Testing** — embedded video after the intro paragraph
- **Automated Testing** — embedded video after the page text

Both use responsive iframes with `aspect-video` styling.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author