### PR TITLE
Rewrite GitHub Actions page with video embed and demo workspace walkthrough

### DIFF
--- a/bru-cli/gitHubCLI.mdx
+++ b/bru-cli/gitHubCLI.mdx
@@ -3,103 +3,164 @@ title: "GitHub Actions Integration"
 sidebarTitle: "GitHub Actions"
 ---
 
-import { BrunoButton } from "/snippets/BrunoButton.jsx";
-
 [GitHub Actions](https://docs.github.com/en/actions) is a powerful continuous integration and continuous delivery (CI/CD) platform that enables you to automate your software development workflows directly from your GitHub repository. It provides seamless integration with GitHub's ecosystem, making it an ideal choice for teams looking to automate their API testing workflows.
 
 Bruno CLI integrates seamlessly with GitHub Actions to automate API testing workflows.
 
-Explore our GitHub Actions collection to see practical examples and test GitHub Actions CI/CD integration:
-
-<BrunoButton 
-  collectionUrl="https://github.com/bruno-collections/github-actions"
-  width={160}
-  height={40}
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/UBAOzICJADs"
+  title="GitHub Actions Integration with Bruno"
+  allowFullScreen
 />
 
+<Note>
+  To follow along with the video, clone the [Bruno Automation Demo Workspace](https://github.com/bruno-collections/bruno-automation-demo-workspace) and open it in Bruno.
+</Note>
+
 ## Prerequisites
-- [Git](https://git-scm.com/downloads) Installed.
-- GitHub repository with Bruno collection.
+- [Git](https://git-scm.com/downloads) installed.
+- A GitHub repository containing a Bruno workspace.
+- [Node.js](https://nodejs.org/) (for installing the Bruno CLI).
 
-## Automate API Testing with GitHub Actions
+## Workspace Structure
 
-1. Ensure your Bruno collections are properly organized in your repository:
+The demo workspace is organized as a Bruno workspace with an OpenCollection layout:
 
 ```
-your-api-project/
+bruno-automation-demo-workspace/
 ├── .github/
 │   └── workflows/
-│       └── api-tests.yml
+│       └── bruno-api-tests.yml
 ├── collections/
-│   ├── authentication/
-│   │   ├── login.bru
-│   │   └── logout.bru
+│   └── bruno-automation-demo/
+│       ├── 01-smoke-checks/
+│       ├── 02-ci-workflow/
+│       ├── 03-release-gates/
+│       ├── environments/
+│       │   ├── ci.bru
+│       │   ├── local.bru
+│       │   └── staging.bru
+│       └── opencollection.yml
 ├── environments/
-│   ├── development.bru
-│   ├── ci.bru
-│   └── production.bru
-└── bruno.json
+│   ├── ci.yml
+│   ├── local.yml
+│   └── staging.yml
+├── workspace.yml
+└── reports/
 ```
 
-2. In your repository, create the following directory structure:
+Key items:
+- **`workspace.yml`** — defines the workspace and points to the collection at `collections/bruno-automation-demo`.
+- **`environments/ci.yml`** — a [global environment](/variables/global-environment-variables) with variables like `bruno_echo_url`, `platform_name`, and `build_id` used across all collections.
+- **`collections/bruno-automation-demo/`** — the collection itself, containing folders of requests with tests and assertions.
+
+## Create the GitHub Actions Workflow
+
+1. In your repository, create the workflow directory:
 
 ```bash
 mkdir -p .github/workflows
 ```
 
-3. Create a new file `.github/workflows/api-tests.yml` sample script:
+2. Create `.github/workflows/bruno-api-tests.yml`:
 
 ```yaml
-name: API Tests
+name: Bruno API Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  test:
+  bruno-tests:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-    
-    - name: Install Bruno CLI
-      run: npm install -g @usebruno/cli
-    
-    - name: Run API Tests
-      run: bru run --env ci --reporter-html results.html
-    
-    - name: Upload Test Results
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results
-        path: results.html
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install Bruno CLI
+        run: npm install -g @usebruno/cli
+
+      - name: Prepare report directory
+        run: mkdir -p reports
+
+      - name: Run Bruno demo collection
+        working-directory: collections/bruno-automation-demo
+        run: |
+          bru run \
+            --global-env ci \
+            --workspace-path ../.. \
+            --tags smoke,workflow,release-gate \
+            --env-var platform_name="GitHub Actions" \
+            --env-var build_id="${{ github.run_id }}" \
+            --env-var commit_sha="${{ github.sha }}" \
+            --reporter-html ../../reports/github-actions-report.html
+
+      - name: Upload Bruno report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: bruno-report
+          path: reports/github-actions-report.html
+          if-no-files-found: error
 ```
 
-4. **Commit and push** your workflow file:
+### What this workflow does
+
+| Step | Purpose |
+| --- | --- |
+| **Check out repository** | Clones your repo so the runner has access to the workspace and collections. |
+| **Set up Node.js** | Installs Node.js, which is required to run the Bruno CLI. |
+| **Install Bruno CLI** | Installs `@usebruno/cli` globally via npm. |
+| **Prepare report directory** | Creates a `reports/` folder for the HTML test report. |
+| **Run Bruno demo collection** | Runs `bru run` from inside the collection directory (see details below). |
+| **Upload Bruno report** | Saves the HTML report as a downloadable GitHub Actions artifact. |
+
+### Key `bru run` flags
+
+- **`--global-env ci`** — activates the `ci` [global environment](/variables/global-environment-variables) defined in `environments/ci.yml` at the workspace root.
+- **`--workspace-path ../..`** — tells Bruno where the workspace root is relative to the collection directory. This is required when running `bru run` from inside a collection folder.
+- **`--tags smoke,workflow,release-gate`** — only runs requests tagged with these values.
+- **`--env-var`** — overrides environment variables at runtime, useful for injecting CI-specific values like the GitHub run ID and commit SHA.
+- **`--reporter-html`** — generates an HTML report of the test results.
+
+For a full list of CLI options, see [Command Options](/bru-cli/commandOptions).
+
+## Run the Workflow
+
+1. **Commit and push** your workflow file:
 ```bash
-git add .github/workflows/api-tests.yml
-git commit -m "Add GitHub Actions workflow for API testing"
+git add .github/workflows/bruno-api-tests.yml
+git commit -m "Add Bruno API test workflow"
 git push origin main
 ```
 
-5. **Monitor the workflow**:
-   - Go to your GitHub repository
-   - Click on the "Actions" tab
-   - You should see your workflow running
+2. **Monitor the workflow**:
+   - Go to your GitHub repository and click the **Actions** tab.
+   - The workflow runs automatically on pushes and pull requests to `main`, or you can trigger it manually with **workflow_dispatch**.
 
-6. **View results**:
-   - Once completed, download the test results from the artifacts section
-   - Open `results.html` in your browser for detailed reports
+3. **View the report**:
+   - Once the run completes, click into the workflow run.
+   - Download the **bruno-report** artifact from the Artifacts section.
+   - Open `github-actions-report.html` in your browser for a visual summary of all test results.
 
 ## Learn More
 
-For more advanced GitHub Actions features and configurations, visit the [GitHub Actions documentation](https://docs.github.com/en/actions).
+- [Bruno CLI Overview](/bru-cli/overview)
+- [Command Options](/bru-cli/commandOptions)
+- [Generating Reports](/bru-cli/builtInReporters)
+- [Global Environment Variables](/variables/global-environment-variables)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)


### PR DESCRIPTION
## Summary

Rewrites the GitHub Actions integration page to embed a YouTube video and align the documentation with the [Bruno Automation Demo Workspace](https://github.com/bruno-collections/bruno-automation-demo-workspace).

## Changes

- **YouTube video embed** — added after the intro text
- **Replaced BrunoButton** with a `<Note>` linking to the demo workspace repo
- **Removed unused `BrunoButton` import**
- **Rewrote the guide** to match the actual demo workspace structure:
  - Updated directory tree to show the OpenCollection YAML layout
  - Replaced the generic workflow YAML with the real `bruno-api-tests.yml` from the demo repo
  - Added a table explaining each workflow step
  - Documented key `bru run` flags (`--global-env`, `--workspace-path`, `--tags`, `--env-var`, `--reporter-html`)
  - Updated "Learn More" section with links to related Bruno docs pages

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author