### PR TITLE
Document that bruno-cli can be installed with Homebrew

### DIFF
--- a/bru-cli/installation.mdx
+++ b/bru-cli/installation.mdx
@@ -6,7 +6,7 @@ title: "Installation"
   Make sure you have Node.js installed on your local system. It is recommended to use the latest LTS version (Node 18 or higher). 
 </Callout>
 
-To install the Bruno CLI, use the node package manager of your choice:
+To install the Bruno CLI, use the package manager of your choice:
 
 <Tabs>
   <Tab title="pnpm">
@@ -28,6 +28,13 @@ To install the Bruno CLI, use the node package manager of your choice:
 
     ```bash
     yarn global add @usebruno/cli
+    ```
+  </Tab>
+  <Tab title="brew">
+    ### Using brew
+
+    ```bash
+    brew install bruno-cli
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
This PR if accepted documents that the bruno-cli can be installed using the [Homebrew](https://brew.sh/) package manager popular among Mac developers and sometimes used by Linux developers. I suggest it because it automatically takes care of the Node dependency.