### PR TITLE
Fix Google Analytics measurement ID

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -885,7 +885,7 @@
   },
   "integrations": {
     "ga4": {
-      "measurementId": "G-EB5Y7HLTX3"
+      "measurementId": "G-ZZBSKJSFZ8"
     }
   },
   "redirects": [


### PR DESCRIPTION
## Summary

This PR corrects the Google Analytics 4 measurement ID to the original production property.

## Changes

- **Changed from**: `G-EB5Y7HLTX3` (incorrect)
- **Changed to**: `G-ZZBSKJSFZ8` (correct production ID)

## Background

The measurement ID `G-ZZBSKJSFZ8` was the original GA4 property configured in the documentation. It was accidentally removed on Jan 27, 2026 in commit `6b6dccf` ("revamp content and remove config files" by ganesh-bruno).

PR #9 restored Google Analytics tracking but used the wrong measurement ID. This PR corrects it to use the original production property.

## Impact

- Restores analytics tracking to the correct Google Analytics property
- Historical data will be preserved in the correct GA4 property