### PR TITLE
Revert to correct Google Analytics measurement ID

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -884,7 +884,7 @@
   },
   "integrations": {
     "ga4": {
-      "measurementId": "G-ZZBSKJSFZ8"
+      "measurementId": "G-EB5Y7HLTX3"
     }
   },
   "redirects": [


### PR DESCRIPTION
## Summary

This PR reverts the measurement ID back to G-EB5Y7HLTX3, which is the correct active GA4 property for Bruno documentation.

## Changes

- Changed from: G-ZZBSKJSFZ8 (incorrect)
- Changed to: G-EB5Y7HLTX3 (correct - active property)

## Background

PR #83 changed the measurement ID to G-ZZBSKJSFZ8 based on historical configuration, but after verification in Google Analytics, G-EB5Y7HLTX3 is confirmed to be the correct, active property for tracking Bruno docs.

This ensures analytics data flows to the correct GA4 property dashboard.