### PR TITLE
Add fetch in Bruno (sample collections)

### DIFF
--- a/advanced-guides/visualize.mdx
+++ b/advanced-guides/visualize.mdx
@@ -3,7 +3,23 @@ title: "Response Visualization"
 sidebarTitle: "Visualizer"
 ---
 
+import { BrunoButton } from "/snippets/BrunoButton.jsx";
+
 Bruno provides a powerful visualization feature that allows you to display API response data in a more readable and interactive format using the `bru.visualize` function. This feature supports multiple providers and formats to help you analyze and present your API data effectively.
+
+## Try it out
+
+Explore the [response-visualizer](https://github.com/bruno-collections/response-visualizer) sample collection to see tables, charts, and HTML views in action:
+
+<BrunoButton
+  collectionUrl="https://github.com/bruno-collections/response-visualizer.git"
+  width={160}
+  height={40}
+/>
+
+## Overview
+
+The `bru.visualize` function allows you to display API response data in a more readable and interactive format using the `bru.visualize` function. This feature supports multiple providers and formats to help you analyze and present your API data effectively.
 
 ```javascript
 bru.visualize(type, config)
@@ -39,7 +55,7 @@ bru.visualize(type, config)
 Handlebars is compiled server-side; the Visualize tab receives the rendered HTML.
 
 
-## Supported Visualization Types and Providers
+## Supported Visualization
 
 ### Table Visualization ('table')
 
@@ -518,4 +534,3 @@ const html = `
 
 bru.visualize('html', { name: 'pieChart', content: html });
 ```
-

--- a/auth/oauth2-2.0/overview.mdx
+++ b/auth/oauth2-2.0/overview.mdx
@@ -7,6 +7,16 @@ import { BrunoButton } from "/snippets/BrunoButton.jsx";
 
 This document describes the OAuth 2 implementation available in Bruno. This approach simplifies authentication handling with automatic token management and flexible configuration options.
 
+## Try it out
+
+Explore the [oauth-keycloak](https://github.com/bruno-collections/oauth-keyclock) sample collections for real-world OAuth2 flows to walk through each grant type step by step:
+
+<BrunoButton
+  collectionUrl="https://github.com/bruno-collections/oauth-keyclock.git"
+  width={160}
+  height={40}
+/>
+
 ## Overview
 
 Bruno supports OAuth 2 authentication at collection, folder and request levels:
@@ -81,14 +91,3 @@ if (res.getStatus() === 401) {
 ```
 
 For the full list of OAuth2 scripting APIs, see the [JavaScript API Reference](/testing/script/javascript-reference#oauth2-credentials).
-
-## Get Started with OAuth2
-
-Feel free to explore our OAuth2 tutorial collection to see practical examples and test different OAuth2 grant types:
-
-<BrunoButton 
-  collectionUrl="https://github.com/bruno-collections/bruno-oauth2-tutorial-collection"
-  width={160}
-  height={40}
-/>
-

--- a/auth/overview.mdx
+++ b/auth/overview.mdx
@@ -3,8 +3,20 @@ title: "Authentication in Bruno"
 sidebarTitle: "Overview"
 ---
 
+import { BrunoButton } from "/snippets/BrunoButton.jsx";
+
 Bruno allows you to send authentication details with your API requests.
 Authentication methods can be set on the request level or collection level, if you want all of your requests to use the same method.
+
+## Try it out
+
+Explore the [oauth-keycloak](https://github.com/bruno-collections/oauth-keyclock) sample collections for real-world OAuth2 flows to walk through each grant type step by step:
+
+<BrunoButton
+  collectionUrl="https://github.com/bruno-collections/oauth-keyclock.git"
+  width={160}
+  height={40}
+/>
 
 <Info>
   Some APIs will require a digital certificate to establish a client's identity.

--- a/get-started/configure/proxy-config.mdx
+++ b/get-started/configure/proxy-config.mdx
@@ -2,9 +2,21 @@
 title: "Configuring Proxy Settings in Bruno"
 ---
 
+import { BrunoButton } from "/snippets/BrunoButton.jsx";
+
 A proxy is an intermediary server that sits between a client application (like Bruno) and the destination server that the client is communicating with (like an API). The proxy server acts as a security barrier, making requests on your behalf to websites and other internet resources, and preventing others from accessing your internal network.
 
 If your machine sits behind a corporate network or firewall, you may need to configure the proxy settings in Bruno in order for requests to be made.
+
+## Try it out
+
+Try the [proxy_configuration](https://github.com/bruno-collections/proxy_configuration) sample collection to see proxy setups in action:
+
+<BrunoButton
+  collectionUrl="https://github.com/bruno-collections/proxy_configuration.git"
+  width={160}
+  height={40}
+/>
 
 <Info>
 Starting from v3.1.0+, **System Proxy is enabled by default for new users** and Existing users retain their current preference settings.

--- a/secrets-management/secret-managers/aws-secrets-manager/overview.mdx
+++ b/secrets-management/secret-managers/aws-secrets-manager/overview.mdx
@@ -3,12 +3,23 @@ sidebarTitle: "Overview"
 ---
 
 import { PremiumBadge } from "/snippets/premium-badge.jsx";
+import { BrunoButton } from "/snippets/BrunoButton.jsx";
 
 # AWS Secret Manager <PremiumBadge noLink />
 
 AWS Secrets Manager is a secure and scalable service designed to store and retrieve sensitive information such as API keys, database credentials, and other secrets. 
 
 Bruno allows you to easily integrate with AWS Secrets Manager and securely access secrets during test execution without exposing them in test scripts or environment variables. 
+
+## Try it out
+
+Explore the [aws-secret-manager](https://github.com/bruno-collections/aws-secret-manager) sample collection to see Bruno's AWS Secrets Manager integration in action:
+
+<BrunoButton
+  collectionUrl="https://github.com/bruno-collections/aws-secret-manager.git"
+  width={160}
+  height={40}
+/>
 
 This guide provides detailed steps to configure and utilize AWS Secrets Manager in Bruno.
 

--- a/secrets-management/secret-managers/azure-key-vault/overview.mdx
+++ b/secrets-management/secret-managers/azure-key-vault/overview.mdx
@@ -3,12 +3,23 @@ sidebarTitle: "Overview"
 ---
 
 import { PremiumBadge } from "/snippets/premium-badge.jsx";
+import { BrunoButton } from "/snippets/BrunoButton.jsx";
 
 # Azure Key Vault <PremiumBadge noLink />
 
 Azure Key Vault is a secure and scalable service designed to store and retrieve sensitive information such as API keys, database credentials, and other secrets. 
 
 Bruno allows you to easily integrate with Azure Key Vault and securely access secrets during test execution without exposing them in test scripts or environment variables. 
+
+## Try it out
+
+Explore the [azure-vault](https://github.com/bruno-collections/azure-vault) sample collection to see Bruno's Azure Key Vault integration in action:
+
+<BrunoButton
+  collectionUrl="https://github.com/bruno-collections/azure-vault.git"
+  width={160}
+  height={40}
+/>
 
 This guide provides detailed steps to configure and utilize Azure Key Vault in Bruno.
 

--- a/secrets-management/secret-managers/hashicorp-vault/overview.mdx
+++ b/secrets-management/secret-managers/hashicorp-vault/overview.mdx
@@ -3,12 +3,23 @@ sidebarTitle: "Overview"
 ---
 
 import { PremiumBadge } from "/snippets/premium-badge.jsx";
+import { BrunoButton } from "/snippets/BrunoButton.jsx";
 
 # HashiCorp Vault <PremiumBadge noLink />
 
 HashiCorp Vault is a tool for managing secrets and protecting sensitive data. It is designed to provide a secure, reliable, and scalable solution for managing secrets such as API keys, passwords, certificates, and other sensitive data. Vault provides a centralized platform for storing and accessing secrets, and includes features such as encryption, access control, auditing, and more.
 
 Bruno allows you to easily integrate Hashicorp Vault and access your secrets securely. With Bruno, you can securely store your Vault credentials and access them without exposing sensitive information.
+
+## Try it out
+
+Explore the [hashiCorp-vault-server](https://github.com/bruno-collections/hashiCorp-vault-server) sample collection to see Bruno's HashiCorp Vault integration in action:
+
+<BrunoButton
+  collectionUrl="https://github.com/bruno-collections/hashiCorp-vault-server.git"
+  width={160}
+  height={40}
+/>
 
 In this guide, we will show you how to set up HashiCorp Vault with Bruno.
 


### PR DESCRIPTION
This PR adds sample collection to try it out feature directly in Bruno:
- [Proxy Configuration](https://bruno-a6972042-docs-add-fetch-bruno.mintlify.app/get-started/configure/proxy-config)
- Secret Managers
   - [AWS](https://bruno-a6972042-docs-add-fetch-bruno.mintlify.app/secrets-management/secret-managers/aws-secrets-manager/overview) 
   - [Azure](https://bruno-a6972042-docs-add-fetch-bruno.mintlify.app/secrets-management/secret-managers/azure-key-vault/overview) 
   - [HashiCorp Vault](https://bruno-a6972042-docs-add-fetch-bruno.mintlify.app/secrets-management/secret-managers/hashicorp-vault/overview#try-it-out) 
- [OAuth2](https://bruno-a6972042-docs-add-fetch-bruno.mintlify.app/auth/oauth2-2.0/overview#try-it-out) 
  - Client Credentials
  - Password Credentials
  - Authorization 
  - [API Key, Digest Auth, Bearer and Basic auth methods](https://bruno-a6972042-docs-add-fetch-bruno.mintlify.app/auth/overview)
- [Response Visualizer](https://bruno-a6972042-docs-add-fetch-bruno.mintlify.app/advanced-guides/visualize#try-it-out)

Add `Try it out` section to top of each page for better visibiltiy. 