### PR TITLE
docs: fix broken agent links/sentences and integrate BigInt guide in nav

### DIFF
--- a/advanced-guides/working-with-bigint.mdx
+++ b/advanced-guides/working-with-bigint.mdx
@@ -2,13 +2,51 @@
 title: "Working with BigInt"
 ---
 
-When your response data contains `BigInt`, the parsed value may become corrupted because Bruno parses the response data by default, which can lead to a loss of fidelity.
-This occurs because `JSON.parse()` does not handle `BigInt` values correctly by default.
+When your response data contains very large integers (`BigInt`), the parsed values may become corrupted. This is because Bruno automatically parses JSON responses using standard JavaScript `JSON.parse()`, which has a precision limit.
 
-However, if you need access to the raw response data (for example, if it contains `BigInt`), you can bypass the parsing step.
+### The Problem
 
-To prevent automatic parsing and work directly with the raw response data, add the below expression to the `pre-request` script.
+JavaScript numbers are double-precision floats. The maximum safe integer in JavaScript is `9007199254740991` (`Number.MAX_SAFE_INTEGER`). Any integer larger than this will lose precision during automatic parsing.
 
-```js
+For example, if your API returns:
+```json
+{
+  "id": 9907199254740993
+}
+```
+
+Standard parsing will corrupt the value:
+```javascript
+// Automatically parsed by standard JSON.parse()
+res.getBody().id // Returns: 9907199254740992 (fidelity lost!)
+```
+
+### The Solution: Bypassing Automatic Parsing
+
+If your API endpoints return high-precision integers (like Snowflake IDs, Twitter IDs, or database 64-bit auto-increments), you can prevent automatic JSON parsing.
+
+To tell Bruno to treat the response body as plain text/raw data, add the following expression to your **Pre-request** script:
+
+```javascript
 req.disableParsingResponseJson();
+```
+
+### Accessing the Raw Data
+
+Once automatic parsing is disabled:
+1. The **Response panel** in the GUI will safely display the raw unparsed JSON without losing precision.
+2. In your **Post-response** or **Test** scripts, `res.getBody()` will return the raw response string instead of a parsed JavaScript object. 
+
+You can then process the string using a library like `json-bigint` or custom regex/parsing logic in your scripts:
+
+```javascript
+// Access the raw string body
+const rawBodyString = res.getBody(); 
+
+// Example: Parse using a custom parser or match the big integer using regex
+const idMatch = rawBodyString.match(/"id":\s*(\d+)/);
+if (idMatch) {
+  const rawId = idMatch[1]; // "9907199254740993" as a safe string
+  console.log("Safely retrieved BigInt ID:", rawId);
+}
 ```

--- a/agents/claude.mdx
+++ b/agents/claude.mdx
@@ -32,7 +32,7 @@ Your project folder structure should look like this:
 </Tree>
 
 <Warning>
-  You can write your own instructions for Claude to follow while working on the collection or you can use the [default instructions provided by Bruno](https://github.com/bruno-collections/ai-assistant-prompts/blob/main/prompts/vscode/.vscode/ai-instructions.md).
+  You can write your own instructions for Claude to follow while working on the collection or you can use the [default instructions provided by Bruno](https://github.com/bruno-collections/ai-assistant-prompts).
 </Warning>
 
 For example workflows and prompts, see [Use cases](./use-cases).

--- a/agents/codex.mdx
+++ b/agents/codex.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Codex"
 [Codex](https://openai.com/codex) is OpenAI's AI-powered coding agent. It reads custom instructions from `AGENTS.md` before doing any work, so you can give it project-specific guidance. With Bruno's local-first approach, you can add an `AGENTS.md` at your project root so Codex understands how to generate and work with Bruno collections.
 
 <Info>
-  Codex discovers instructions in this order: global `~/.codex/AGENTS.md`, See [Custom instructions with AGENTS.md](https://developers.openai.com/codex/guides/agents-md/) for full details.
+  Codex discovers instructions in this order: global `~/.codex/AGENTS.md`, then repo-root `AGENTS.md`, then `AGENTS.md` files in subdirectories. See [Custom instructions with AGENTS.md](https://developers.openai.com/codex/guides/agents-md/) for full details.
 </Info>
 
 ## Configure Codex with Bruno

--- a/docs.json
+++ b/docs.json
@@ -427,7 +427,8 @@
                 "group": "Advanced Guides",
                 "icon": "graduation-cap",
                 "pages": [
-              "advanced-guides/visualize"
+              "advanced-guides/visualize",
+              "advanced-guides/working-with-bigint"
             ]
           }
         ]


### PR DESCRIPTION
### Summary
This PR fixes navigation issues, resolves broken links/sentences in AI agent instructions, and expands the BigInt documentation.

### Changes
* **docs.json**: Added the orphaned `working-with-bigint` page to the sidebar navigation.
* **agents/codex.mdx**: Completed a broken sentence about custom instruction lookup order.
* **agents/claude.mdx**: Fixed a link that was incorrectly pointing to a VS Code-specific file.
* **working-with-bigint.mdx**: Expanded the guide to explain JavaScript's float limit and added a regex code sample for capturing raw IDs.