### PR TITLE
Docs/saml sso updates

### DIFF
--- a/license-administrators/saml-sso/configure-saml-sso-with-okta.mdx
+++ b/license-administrators/saml-sso/configure-saml-sso-with-okta.mdx
@@ -85,47 +85,78 @@ Copy the values from the Bruno SSO settings page and paste them into your SAML c
 
 ### Step 4: Configure Attribute Statements
 
-Bruno requires two specific SAML attributes to be configured. Add the following attribute statements:
+Bruno needs the user's full name plus a role/group value to map them to access levels in the License Portal. You can send the role/group value using **either or both** of two approaches — choose what fits how your organization manages access in Okta:
 
-| Name | Name Format | Value | Notes |
-|------|-------------|-------|-------|
-| **roles** | Unspecified | Any role value from Okta | Can be a static value (e.g., `"admin"`) or mapped to existing Okta user attributes/groups |
-| **fullName** | Unspecified | `user.firstName+" "+user.lastName` | Concatenates first and last name. Can also use a single name field if available. |
+- **Option A: `roles` Profile Attribute Statement** — Send a per-user role value (a static value, a user attribute, etc.)
+- **Option B: `groups` Group Attribute Statement** — Send the names of Okta groups the user belongs to (required if you assign users to the Bruno app via **Assign to Groups**)
+
+Both approaches are equally valid and can be used together. Bruno recognizes the attribute names `role`, `roles`, `group`, and `groups` (case-insensitive) for role mapping.
+
+Add the following attribute statements to your Okta SAML configuration:
+
+| Name | Source | Notes |
+|------|--------|-------|
+| **fullName** | `user.firstName+" "+user.lastName` or equivalent attribute | Required. Represents the combined user's first and last name. |
+| **roles** or **groups** | A role value (Option A) or a group filter (Option B) | Use `roles` as a Profile Attribute Statement (Option A), OR use `groups` via Group Attribute Statements (Option B), OR both. See details below. |
+
+#### Option A: `roles` Profile Attribute Statement
+
+In Okta's **Attribute Statements** section, add:
+
+| Name | Name Format | Value |
+|------|-------------|-------|
+| **roles** | Unspecified | Any role value from Okta |
 
 <Info>
-**Configuring the roles attribute:**
+**Configuring the `roles` attribute:**
 
 The `roles` attribute can be configured in several ways:
 
 1. **Static value for testing**: Set a hardcoded value like `"admin"` for all users assigned to this app
    - Example: Value = `"admin"`
 
-2. **Map to existing or created Okta user attribute**: If your Okta users already have a role attribute or you create a specific attribute for Bruno roles
+2. **Map to an existing or created Okta user attribute**: If your Okta users already have a role attribute or you create a specific attribute for Bruno roles
    - Example: Value = `user.userType` or `user.role` or `user.brunoRole`
 
-{/* 3. **Map to Okta group membership**: Use an Okta expression to map group names
-   - Example: Value = `appuser.groups` (requires group attribute statement configuration) */}
-
-**Important**: The role value sent by Okta will be mapped to Bruno access levels in the License Portal's SSO Settings. You'll configure which role values correspond to admin or user access in Bruno (see Step 2 in the Bruno configuration section below).
+**Important**: The role value sent by Okta will be mapped to Bruno access levels in the License Portal's SSO Settings. You'll configure which role values correspond to admin or user access in Bruno (see Step 3 in the Bruno configuration section below).
 
 **Example Scenarios:**
 - If you set Value = `"Engineering"`, you'll add `Engineering` to either "Admin Roles" or "User Roles" in Bruno
 - If you set Value = `user.department`, and a user's department is `IT`, you'll add `IT` to the appropriate role field in Bruno
 </Info>
 
-<Info>
-**Configuring the fullName attribute:**
+#### Option B: `groups` Group Attribute Statement
 
-The `fullName` attribute can be configured by:
+If you assign users to the Bruno app via Okta groups (**Assign to Groups**) and rely on group membership for role mapping, configure a Group Attribute Statement. Without it, Okta will not include group membership in the SAML assertion and group-assigned users with no Profile `roles` value will receive a "You do not have necessary permissions" error.
+
+In Okta's **Group Attribute Statements** section, add:
+
+| Name | Name Format | Filter | Value |
+|------|-------------|--------|-------|
+| **groups** | Unspecified | Matches regex | `.*` |
+
+<Info>
+**Filtering Groups:**
+
+Using `Matches regex` with `.*` sends all group names the user belongs to. You can narrow this down:
+- **Starts with**: e.g., `bruno-` to only send groups starting with "bruno-"
+- **Equals**: e.g., `bruno-admins` to send only a specific group
+- **Contains**: e.g., `bruno` to send groups containing "bruno"
+
+The group names sent must match the values you configure in Bruno's **Admin Roles** or **User Roles** fields.
+</Info>
+
+#### Configuring the `fullName` attribute
+
+The `fullName` attribute is always required as a Profile Attribute Statement, regardless of which option(s) you use above. It can be configured by:
 - Concatenating first and last name: `user.firstName+" "+user.lastName`
 - Using a single field if your Okta user profile has a combined name field
 - Mapping to any existing user property that contains the full name
-</Info>
 
 ![Configure attribute statements in Okta showing roles and fullName](/images/screenshots/sso-scim-management/okta/okta-sso-5.webp)
 
 <Warning>
-**Important**: Both `roles` and `fullName` attributes are required for Bruno SAML SSO to function correctly. The attribute names are case-sensitive and must match exactly as shown.
+**Important**: The `fullName` attribute plus at least one role/group source (`roles` Profile Attribute Statement, `groups` Group Attribute Statement, or both) are required for Bruno SAML SSO to function correctly. Attribute names are case-sensitive and must match exactly as shown.
 </Warning>
 
 **Preview the SAML Assertion**
@@ -228,6 +259,7 @@ The role value you configured in Okta's `roles` attribute statement will be sent
 1. In your Okta Bruno application, navigate to the **Assignments** tab
 2. Click **Assign** → **Assign to People** or **Assign to Groups**
    - **Note**: Users assigned must already exist in your subscription under the Bruno License Portal in order to login with SSO
+   - **Important**: If assigning via **Assign to Groups**, make sure you have configured a **Group Attribute Statement** in [Step 4](#step-4-configure-attribute-statements). Without it, Okta will not send group membership in the SAML assertion and users will get a permissions error.
 3. Select the users or groups that should have access to Bruno
 4. Click **Assign** and **Done**
 

--- a/license-administrators/saml-sso/troubleshooting.mdx
+++ b/license-administrators/saml-sso/troubleshooting.mdx
@@ -1,3 +1,7 @@
+---
+title: "SAML SSO Troubleshooting"
+sidebarTitle: "Troubleshooting"
+---
 
 This guide helps you diagnose and resolve common issues when configuring or using SAML Single Sign-On with Bruno.
 
@@ -76,9 +80,77 @@ Both steps are required for SSO login to work.
 **Tip**: If you're not sure what values to use, refer to the [SAML SSO Overview](./overview) page for detailed explanations of each field.
 </Info>
 
----
-title: "SAML SSO Troubleshooting"
-sidebarTitle: "Troubleshooting"
+## Inspect the SAML Response with SAML-tracer
+
+<Info>
+**Highly Recommended Early Step**: Before working through specific error messages below, capture the SAML response using the [SAML-tracer browser extension](https://chromewebstore.google.com/detail/saml-tracer/mpdajninpobndbfcldcmbpnnbhibjmch). It exposes the exact attributes (e.g., `roles`, `fullName`, `NameID`) your IdP is sending to Bruno, which makes diagnosing most common issues significantly faster.
+</Info>
+
+The SAML-tracer extension captures SAML requests and responses as they flow through the browser, letting you see exactly what your IdP is sending without having to decode `SAMLResponse` payloads from the Network tab manually.
+
+**Setup:**
+1. Install [SAML-tracer](https://chromewebstore.google.com/detail/saml-tracer/mpdajninpobndbfcldcmbpnnbhibjmch) from the Chrome Web Store (also available for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/saml-tracer/))
+2. Click the SAML-tracer icon in your browser toolbar to open the tracer window
+3. Leave the tracer window open and attempt SSO login from Bruno
+
+**What to verify in the captured SAML response:**
+1. In the SAML-tracer window, find the request flagged with a `SAML` badge that POSTs to `/api/v2/auth/sso/saml/acs/...`
+2. Click the request and open the **SAML** tab to view the decoded XML
+3. Confirm the following values are present and correct:
+   - **NameID**: Should be the user's email address (Bruno uses this to identify the user)
+   - **`roles` attribute**: Should contain a value that exactly matches one of your Admin Roles or User Roles in Bruno (case-sensitive)
+   - **`fullName` attribute** (or `firstName` + `lastName` as fallback): Should contain the user's name
+   - **Destination** and **AudienceRestriction**: Should match Bruno's ACS URL and SP Entity ID respectively
+
+**Example of a healthy SAML response (key sections):**
+
+```xml
+<saml2:Subject>
+  <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">jane.doe@example.com</saml2:NameID>
+</saml2:Subject>
+
+<saml2:Conditions NotBefore="2026-05-26T12:00:00Z" NotOnOrAfter="2026-05-26T12:05:00Z">
+  <saml2:AudienceRestriction>
+    <saml2:Audience>bruno-demo</saml2:Audience>
+  </saml2:AudienceRestriction>
+</saml2:Conditions>
+
+<saml2:AttributeStatement>
+  <saml2:Attribute Name="roles" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+    <saml2:AttributeValue xsi:type="xs:string">admin</saml2:AttributeValue>
+  </saml2:Attribute>
+  <saml2:Attribute Name="fullName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+    <saml2:AttributeValue xsi:type="xs:string">Jane Doe</saml2:AttributeValue>
+  </saml2:Attribute>
+</saml2:AttributeStatement>
+```
+
+In this example:
+- `NameID` is `jane.doe@example.com` — Bruno uses this email to identify the user
+- `<saml2:Audience>` is `bruno-demo` — must match Bruno's **SP Issuer ID / Entity ID** exactly
+- `roles` is `admin` — must match a value in Bruno's **Admin Roles** (or **User Roles**) field, case-sensitive
+- `fullName` is `Jane Doe` — populates the user's display name in Bruno
+
+<Info>
+If you're using `firstName` and `lastName` as a fallback instead of `fullName`, the `<saml2:AttributeStatement>` would contain two separate attributes named `firstName` and `lastName`, which Bruno will combine with a space.
+</Info>
+
+<Info>
+If you're using **group claims** (common with Entra ID), the attribute will be named `groups` instead of `roles`, and may contain multiple `<saml2:AttributeValue>` entries — one per group. Bruno checks if ANY of the values match your configured Admin Roles or User Roles.
+</Info>
+
+**Common issues this quickly reveals:**
+- The `roles` (or `groups`) attribute is missing entirely → IdP attribute statement not configured
+- The `roles` value doesn't match what's in Bruno's Admin Roles / User Roles → role mapping mismatch (often a casing or whitespace issue)
+- NameID is not an email address → IdP NameID format misconfigured
+- `fullName` is missing → user profile shows email instead of name
+- Destination / Audience values don't match Bruno → ACS URL or Entity ID mismatch
+- Attribute name uses a full URI (e.g., `http://schemas.microsoft.com/.../groups`) instead of `groups` → Bruno only recognizes the short names `role`, `roles`, `group`, `groups`
+
+<Warning>
+**Sensitive Data**: SAML responses contain user identity information and signed assertions. When sharing captures with Bruno support, redact any data you don't want to expose.
+</Warning>
+
 ## Common Error Messages
 
 ### "500 Internal Server Error" When Clicking "Login with SSO"
@@ -143,14 +215,14 @@ This error occurs when Bruno tries to generate a SAML authentication request but
    - The subscription ID is shown in the Bruno License Portal SSO settings page
    - This URL must match EXACTLY what's configured in Bruno
    - Copy this URL exactly from the Bruno SSO settings page
-3. **Ensure SSO is enabled in Bruno**:
+2. **Ensure SSO is enabled in Bruno**:
    - IdP test login will fail if SSO is not fully configured and enabled in Bruno
    - Complete the Bruno SSO configuration first, then test from your IdP
-4. **Check the full error message**: The error message may be truncated. Try:
+3. **Check the full error message**: The error message may be truncated. Try:
    - Opening the test in a new incognito/private browser window
    - Checking the browser console for the full error message
    - Looking at the Network tab in Developer Tools for the failed request
-5. **Common error patterns**:
+4. **Common error patterns**:
    - Reply URL mismatch: Check ACS URL configuration
    - Authentication method mismatch: Verify SAML 2.0 is configured
    - User not assigned: Ensure user is assigned to the Bruno application


### PR DESCRIPTION
## What

Two related updates to the SAML SSO documentation under `license-administrators/saml-sso/`:

### 1. `configure-saml-sso-with-okta.mdx` — clarify roles vs groups attribute options

Restructures **Step 4: Configure Attribute Statements** into two clearly labeled options so admins can pick the approach that matches how they manage access in Okta:

- **Option A — `roles` Profile Attribute Statement:** per-user role value (static, mapped to a user attribute, etc.)
- **Option B — `groups` Group Attribute Statement:** required when users are assigned to the Bruno app via **Assign to Groups**

Other changes on this page:
- Adds a `groups` attribute table with filter guidance (`Matches regex .*`, `Starts with`, `Equals`, etc.)
- Clarifies that `fullName` plus at least one role/group source is required
- Adds a cross-reference from **Step 7 (Assign Users)** back to **Step 4** so admins assigning via groups don't miss the Group Attribute Statement requirement

### 2. `troubleshooting.mdx` — add SAML-tracer guidance

Adds a new **"Inspect the SAML Response with SAML-tracer"** section as an early debugging step (before the per-error sections). Covers:
- Installing the SAML-tracer Chrome/Firefox extension
- What to verify in the captured response (`NameID`, `roles`, `fullName`, `Destination`, `AudienceRestriction`)
- An annotated healthy SAML response example (Subject, Conditions, AttributeStatement)
- Variant notes for `firstName`/`lastName` fallback and `groups` claims (common with Entra ID)
- A short list of common misconfigurations the trace makes obvious at a glance

Also fixed on the same page:
- Moved the page's frontmatter (`title` / `sidebarTitle`) from the middle of the body back to the top of the file with a proper closing fence — the sidebar title wasn't rendering correctly before
- Fixed a broken numbered list under **"IdP Test Login Shows Error or Redirects to Bruno Login Page"** that jumped from `1` to `3` (now `1 → 2 → 3 → 4`)

## Why

We've been helping customers troubleshoot SAML issues frequently, and two patterns keep coming up:

1. **Okta group-assigned users hit "You do not have necessary permissions"** because Okta doesn't include group membership in the SAML assertion without an explicit Group Attribute Statement — and the existing doc only covered the `roles` Profile Attribute path.
2. **Most other SAML issues resolve in minutes once the actual response XML is in front of you** (wrong role value, missing attribute, NameID format mismatch, audience mismatch). Surfacing SAML-tracer as an early debugging step should let admins self-serve most common problems before reaching the per-error sections.

## Scope

Two files under `license-administrators/saml-sso/`. No structural/navigation changes elsewhere.
```