### PR TITLE
Add Public collection reference to Introduction section

### DIFF
--- a/bru-cli/commandOptions.mdx
+++ b/bru-cli/commandOptions.mdx
@@ -122,7 +122,7 @@ bru run <folder-1-name> request1.bru <folder-2-name> request2.bru
 
 Now that you're familiar with the command options, explore these guides to get the most out of Bruno CLI:
 
-1. [Run a Collection](/bru-cli/runCollection) - Learn how to execute your collections with the above command options
+1. [Command Examples](/bru-cli/runCollection) - Learn how to execute your collections with the above command options
 2. [Import Data](/bru-cli/import) - Import OpenAPI and WSDL specifications into Bruno collections
 3. [Generate Reports](/bru-cli/builtInReporters) - Create detailed test reports in multiple formats
 

--- a/bru-cli/runCollection.mdx
+++ b/bru-cli/runCollection.mdx
@@ -188,10 +188,6 @@ Each `--env-var` flag adds or overrides a single environment variable, and you c
 
 Bruno CLI supports filtering requests by tags, allowing you to run only specific subsets of your collection based on tag criteria.
 
-<Info>
-  This feature requires [Bruno CLI <strong><sup>↗</sup></strong>](https://www.npmjs.com/package/@usebruno/cli) version 2.8.0 or higher.
-</Info>
-
 ### Include Tags
 
 Run only requests that have at least one matching tag.

--- a/bru-cli/runCollection.mdx
+++ b/bru-cli/runCollection.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Running a Collection"
-sidebarTitle: "Run a Collection"
+title: "Command Examples"
+sidebarTitle: "Command Examples"
 ---
 
 Bruno CLI allows you to run your API collections with ease, either by directly executing requests or using external data sources.

--- a/introduction/getting-started.mdx
+++ b/introduction/getting-started.mdx
@@ -39,7 +39,7 @@ Bruno is a Git-friendly, offline-first API client built for developers who want 
 
 ## Explore Public Collections
 
-Want to see Bruno in action right away? Check out [Bruno Public Collections](https://github.com/bruno-collections) — a library of ready-to-use API collections you can clone, open in Bruno, and start experimenting with instantly. It's the fastest way to experience the power of a Git-based API client.
+Want to see Bruno in action right away? Check out [Bruno Public Collections](https://github.com/bruno-collections) — a GitHub repository of ready-to-use API collections you can clone, open in Bruno, and start experimenting with instantly. It's the fastest way to experience the power of a Git-based API client.
 
 ## Why Bruno?
 

--- a/introduction/getting-started.mdx
+++ b/introduction/getting-started.mdx
@@ -37,6 +37,10 @@ Bruno is a Git-friendly, offline-first API client built for developers who want 
   </Card>
 </CardGroup>
 
+## Explore Public Collections
+
+Want to see Bruno in action right away? Check out [Bruno Public Collections](https://github.com/bruno-collections) — a library of ready-to-use API collections you can clone, open in Bruno, and start experimenting with instantly. It's the fastest way to experience the power of a Git-based API client.
+
 ## Why Bruno?
 
 - **[Git-friendly collaboration](/git-integration/overview)** — store collections as files and review API changes like code.


### PR DESCRIPTION
- Add Public collection reference to Introduction page - introduction/getting-started
- Rename title, sidebarTitle properties in - bru-cli/runCollection document to `Command Examples` for better readability 