### PR TITLE
Fix link in overview.mdx

### DIFF
--- a/testing/automate-test/overview.mdx
+++ b/testing/automate-test/overview.mdx
@@ -2,7 +2,7 @@
 title: "Overview"
 ---
 
-Bruno offers multiple ways to run your API tests. Testing is crucial for APIs, as a single failure can bring down the entire application. With Bruno, you can automate API tests using the [Collection Runner <strong><sup>↗</sup></strong>](https://docs.usebruno.com/bruno-basics/run-a-collection) or the [Bruno CLI <strong><sup>↗</sup></strong>](https://docs.usebruno.com/bru-cli/overview) to integrate testing into your CI/CD pipeline.
+Bruno offers multiple ways to run your API tests. Testing is crucial for APIs, as a single failure can bring down the entire application. With Bruno, you can automate API tests using the [Collection Runner <strong><sup>↗</sup></strong>](https://docs.usebruno.com/get-started/bruno-basics/run-a-collection) or the [Bruno CLI <strong><sup>↗</sup></strong>](https://docs.usebruno.com/bru-cli/overview) to integrate testing into your CI/CD pipeline.
 
 ### Automated Testing in CI/CD
 


### PR DESCRIPTION
Replaces the incorrect link in the Core Features -> Tests and Scripts -> Automate Tests -> Overview page (which results in a 404) with the correct link.