### PR TITLE
fix: remove undefined 'body' variable in quick-start scrupt example

### DIFF
--- a/introduction/quick-start.mdx
+++ b/introduction/quick-start.mdx
@@ -237,7 +237,6 @@ req.setBody({
 })
 
 req.setHeader("Content-Type", "application/json");
-req.setBody(body);
 console.log(req.getName())
 ```
 3. Execute the request and verify that the response body matches the body of the request.
@@ -515,4 +514,3 @@ Congratulations on completing the Quick Start guide! You have learned the basics
 
 
 ---
-


### PR DESCRIPTION
This code in section 6 of the quick start guide 

``req.setBody({
  "name":"<your name>",
  "msg":"<your message>"
})

req.setHeader("Content-Type", "application/json");
req.setBody(body);
console.log(req.getName())````

causes the exception 

```
ReferenceError: 'body' is not defined
````

Removing the additional setBody resolves this.