### PR TITLE
v4-updates

### DIFF
--- a/ai/bruno-ai/introduction.mdx
+++ b/ai/bruno-ai/introduction.mdx
@@ -41,3 +41,4 @@ Open the Docs tab, click the AI icon, and describe the endpoint or workflow. Bru
 
 - [Configure providers and models](/ai/bruno-ai/configuration)
 - [Using Bruno AI features](/ai/bruno-ai/usage)
+- [Builds Apps with Bruno AI](/apps/ai-with-apps)

--- a/apps/ai-with-apps.mdx
+++ b/apps/ai-with-apps.mdx
@@ -74,7 +74,7 @@ A collection-level App can see every request in your collection. The AI uses thi
 
 ---
 
-## Tips for better results
+## Tips
 
 - **Be specific about the UI.** "A form with Email and Password inputs, a Login button, and a status message" gives better output than "a login form".
 - **Mention what to do with the response.** "Display the `token` field from the response" is more precise than "show the result".

--- a/apps/api-ref.mdx
+++ b/apps/api-ref.mdx
@@ -225,7 +225,7 @@ Both `submitRequest` and `runRequest` accept an optional `options` object:
 
 ---
 
-## Notes & gotchas
+## Tips
 
 **`bru.ctx.theme` is an object, not a string.**
 Use `bru.ctx.theme.mode` for the light/dark switch. The mode is also mirrored as a `light` / `dark` class on `document.body`.

--- a/secrets-management/secret-managers/migration.mdx
+++ b/secrets-management/secret-managers/migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migration Guide
-sidebarTitle: Migration Guide
+sidebarTitle: V4 Migration Guide
 description: Move your Secret Manager configuration from secrets.json to environment files.
 ---
 
@@ -193,7 +193,7 @@ Both work in v4. The old syntax is shown with a deprecation underline in the edi
 
 ---
 
-## Gotchas
+## Tips
 
 **The CLI will not run if `secrets.json` exists without a migrated environment file.**
 The CLI prints a warning and continues without secrets — it does not fail hard, but requests that depend on secrets will receive empty values. Fix: open the collection in the app first.

--- a/variables/overview.mdx
+++ b/variables/overview.mdx
@@ -54,10 +54,10 @@ Each variable has its own storage location either within your collection file or
 
 | Variable Type | Storage Location |
 |---|---|
-| Collection | `<collection-name>.bru` |
-| Folder | `<folder-name>.bru` |
-| Request | `<request-name>.bru` |
-| Environment | `<env-name>.bru` |
+| Collection | `opencollection.yml` |
+| Folder | `folder.yml` |
+| Request | `request.yml` |
+| Environment | `<env-name>.yml` |
 | Runtime | Local storage |
 | Global | Local storage |
 | Prompt | Never stored |
@@ -78,28 +78,9 @@ Starting with v4.0.0, variables are no longer limited to strings. You can store 
 | `boolean` | `true` |
 | `object` | `{ "host": "localhost" }` |
 
-In `.bru` files, types are stored using `@number`, `@boolean`, or `@object` annotations placed on the line immediately above the variable. Object values use triple-quote (`'''`) blocks. In `.yml` files, each variable is an object with a `type` field and a `data` field.
+In `.yml` files, each variable is an object with a `type` field and a `data` field. In `.bru` files, types are stored using `@number`, `@boolean`, or `@object` annotations placed on the line immediately above the variable. Object values use triple-quote (`'''`) blocks.
 
 <CodeGroup>
-```bru BRU format (.bru)
-vars:pre-request {
-  @number
-  timeout: 30
-
-  @boolean
-  debug: true
-
-  @object
-  config: '''
-    {
-      "host": "localhost",
-      "port": 8080
-    }
-  '''
-
-  baseUrl: https://api.example.com
-}
-```
 
 ```yaml YAML format (.yml)
 runtime:
@@ -122,6 +103,27 @@ runtime:
     - name: baseUrl
       value: https://api.example.com
 ```
+
+```bru BRU format (.bru)
+vars:pre-request {
+  @number
+  timeout: 30
+
+  @boolean
+  debug: true
+
+  @object
+  config: '''
+    {
+      "host": "localhost",
+      "port": 8080
+    }
+  '''
+
+  baseUrl: https://api.example.com
+}
+```
+
 </CodeGroup>
 
 **Setting typed variables from scripts**


### PR DESCRIPTION
- Promoting `yml` instead of `bru` by default 
- Change migration guide to `V4 Migration Guide` in secret manager section
- Minor changes 