### PR TITLE
docs: note bru.ctx lives in the Apps API Reference

### DIFF
--- a/testing/script/javascript-reference.mdx
+++ b/testing/script/javascript-reference.mdx
@@ -6,6 +6,10 @@ sidebarTitle: "JavaScript Reference"
 Bruno offers powerful scripting capabilities that allow you to extend and automate your API testing workflows.
 Here is the complete set of API reference for the scripting feature in Bruno.
 
+<Note>
+  This page covers the APIs available in **scripts and tests** (`req`, `res`, and `bru`). [Apps](/apps/overview) use a separate API — `bru.ctx` — which is injected into the App's page instead of the scripting sandbox, and is not available in scripts. See the [Apps API Reference](/apps/api-ref) for the full `bru.ctx` surface.
+</Note>
+
 ## Request
 
 The `req` variable represents the HTTP request object and is automatically available inside your scripting and testing context. It provides methods to access and modify the current request's properties such as URL, method, headers, body, and other configuration options before the request is sent to the server.


### PR DESCRIPTION
## Problem

The [JavaScript Reference](https://docs.usebruno.com/testing/script/javascript-reference) documents only the scripting APIs — `req`, `res`, and `bru` — and never mentions `bru.ctx`. Readers who go looking for `bru.ctx` on the JS reference page find nothing and no pointer to where it actually lives.

## Change

Adds a `<Note>` directly under the intro that:

- scopes this page to scripts and tests (`req`, `res`, `bru`),
- explains that Apps use a separate `bru.ctx` API injected into the App's page rather than the scripting sandbox, and that it is not available in scripts,
- links to [Apps](/apps/overview) and the [Apps API Reference](/apps/api-ref) for the full `bru.ctx` surface.

## Notes

Only the current-version page is changed. `v2/` and `v3/` have no Apps section in `docs.json`, so `/apps/api-ref` would be a broken link there.

Verified locally with `mint dev` — the callout renders and both links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)