### PR TITLE
docs: add floating webinar registration card

### DIFF
--- a/webinar-card.js
+++ b/webinar-card.js
@@ -1,0 +1,81 @@
+// Floating registration card for the "Bruno v4 Live" webinar.
+// Desktop: card pinned bottom-right. Mobile: slim bar pinned to the bottom edge.
+// Auto-hides after the event ends; safe to delete after 2026-08-19.
+(function () {
+  var KEY = "bruno-webinar-2026-08-19";
+  var ENDS = Date.parse("2026-08-19T16:00:00Z"); // 12:00 PM EDT
+
+  if (Date.now() > ENDS) return;
+
+  try {
+    if (localStorage.getItem(KEY)) return;
+  } catch (e) {
+    // Private browsing / storage blocked — show the card, just don't persist dismissal.
+  }
+
+  var render = function () {
+    if (document.getElementById("bru-webinar")) return;
+
+    var el = document.createElement("div");
+    el.innerHTML =
+      "<style>" +
+      "#bru-webinar{position:fixed;bottom:1.25rem;right:1.25rem;z-index:60;width:20rem;" +
+      "max-width:calc(100vw - 2.5rem);padding:1rem;border-radius:.75rem;border:1px solid #E5E7EB;" +
+      "background:#fff;color:#111827;box-shadow:0 10px 30px rgba(0,0,0,.12);font-size:.875rem;" +
+      "line-height:1.4}" +
+      ".dark #bru-webinar{background:#0F1117;border-color:#26272B;color:#F3F4F6;" +
+      "box-shadow:0 10px 30px rgba(0,0,0,.5)}" +
+      "#bru-webinar .bru-eyebrow{display:flex;align-items:center;gap:.4rem;font-size:.6875rem;" +
+      "font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:#F2994A}" +
+      "#bru-webinar .bru-dot{flex:none;width:.4rem;height:.4rem;border-radius:9999px;" +
+      "background:#F2994A}" +
+      "#bru-webinar .bru-narrow{display:none}" +
+      "#bru-webinar h4{margin:.5rem 0 .25rem;font-size:.9375rem;font-weight:600}" +
+      "#bru-webinar p{margin:0;opacity:.7;font-size:.8125rem}" +
+      "#bru-webinar a.bru-cta{display:inline-block;margin-top:.75rem;padding:.4rem .75rem;" +
+      "border-radius:.5rem;background:#F2994A;color:#fff;font-weight:600;text-decoration:none}" +
+      "#bru-webinar button{position:absolute;top:.5rem;right:.5rem;border:0;background:none;" +
+      "cursor:pointer;color:inherit;opacity:.5;font-size:1rem;line-height:1;padding:.25rem}" +
+      "#bru-webinar button:hover{opacity:1}" +
+      // Mobile: collapse the card into a single-line bar across the bottom edge.
+      "@media (max-width:640px){" +
+      "#bru-webinar{left:0;right:0;bottom:0;width:auto;max-width:none;display:flex;" +
+      "align-items:center;gap:.625rem;padding:.625rem .875rem;" +
+      "padding-bottom:calc(.625rem + env(safe-area-inset-bottom));border-radius:0;" +
+      "border-left:0;border-right:0;border-bottom:0;box-shadow:0 -4px 16px rgba(0,0,0,.1)}" +
+      ".dark #bru-webinar{box-shadow:0 -4px 16px rgba(0,0,0,.5)}" +
+      "#bru-webinar h4,#bru-webinar p,#bru-webinar .bru-wide{display:none}" +
+      "#bru-webinar .bru-narrow{display:inline}" +
+      "#bru-webinar .bru-eyebrow{flex:1;min-width:0}" +
+      "#bru-webinar .bru-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}" +
+      "#bru-webinar a.bru-cta{flex:none;margin-top:0;font-size:.8125rem}" +
+      "#bru-webinar button{position:static;flex:none;font-size:1.125rem}" +
+      "}" +
+      "</style>" +
+      '<div id="bru-webinar" role="complementary" aria-label="Upcoming webinar">' +
+      '<button type="button" aria-label="Dismiss webinar notification">&times;</button>' +
+      '<div class="bru-eyebrow"><span class="bru-dot"></span>' +
+      '<span class="bru-label"><span class="bru-wide">Live webinar</span>' +
+      '<span class="bru-narrow">v4 Webinar</span> &middot; Aug 19</span></div>' +
+      "<h4>Bruno v4 Live: AI, Scripting, Docs &amp; What’s New</h4>" +
+      "<p>11:00 AM EDT / 4:00 PM BST &middot; Zoom</p>" +
+      '<a class="bru-cta" href="https://www.usebruno.com/webinar" target="_blank" rel="noopener">' +
+      'Register <span class="bru-wide">free </span>→</a>' +
+      "</div>";
+
+    document.body.appendChild(el);
+
+    el.querySelector("button").addEventListener("click", function () {
+      try {
+        localStorage.setItem(KEY, "1");
+      } catch (e) {}
+      el.remove();
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", render);
+  } else {
+    render();
+  }
+})();

--- a/webinar-card.js
+++ b/webinar-card.js
@@ -19,8 +19,12 @@
     var el = document.createElement("div");
     el.innerHTML =
       "<style>" +
-      "#bru-webinar{position:fixed;bottom:1.25rem;right:1.25rem;z-index:60;width:20rem;" +
-      "max-width:calc(100vw - 2.5rem);padding:1rem;border-radius:.75rem;border:1px solid #E5E7EB;" +
+      // right/max-width track --assistant-sheet-width so the card slides aside when the AI
+      // assistant panel opens, the same way Mintlify's own fixed navbar does.
+      "#bru-webinar{position:fixed;bottom:1.25rem;z-index:60;width:20rem;" +
+      "right:calc(1.25rem + var(--assistant-sheet-width, 0px));" +
+      "max-width:calc(100vw - 2.5rem - var(--assistant-sheet-width, 0px));" +
+      "padding:1rem;border-radius:.75rem;border:1px solid #E5E7EB;" +
       "background:#fff;color:#111827;box-shadow:0 10px 30px rgba(0,0,0,.12);font-size:.875rem;" +
       "line-height:1.4}" +
       ".dark #bru-webinar{background:#0F1117;border-color:#26272B;color:#F3F4F6;" +
@@ -37,6 +41,9 @@
       "#bru-webinar button{position:absolute;top:.5rem;right:.5rem;border:0;background:none;" +
       "cursor:pointer;color:inherit;opacity:.5;font-size:1rem;line-height:1;padding:.25rem}" +
       "#bru-webinar button:hover{opacity:1}" +
+      // Below 1024px the assistant is a bottom drawer, and search/mobile-nav are modals — all
+      // Radix dialogs. Stand down entirely rather than cover their inputs.
+      "html:has([role=dialog][data-state=open]) #bru-webinar{display:none}" +
       // Mobile: collapse the card into a single-line bar across the bottom edge.
       "@media (max-width:640px){" +
       "#bru-webinar{left:0;right:0;bottom:0;width:auto;max-width:none;display:flex;" +


### PR DESCRIPTION
## What

Adds a dismissible notification promoting the [Bruno v4 Live webinar](https://www.usebruno.com/webinar) on **Aug 19, 2026**.

## Why a card instead of a banner

`docs.json` supports a single `banner` object, and that slot is in use for the v4 breaking-changes warning. Rather than dilute that warning with a second CTA, this adds an independent surface: a root-level custom script, which Mintlify injects on every page (same mechanism as the existing `reo.js`).

A `navbar.primary` button was also tried and dropped — it occupies the same navbar slot as the AI Assistant trigger and hides it.

## Design

**Desktop** — card pinned bottom-right:

```
┌─────────────────────────────────┐
│ ● LIVE WEBINAR · AUG 19     [×] │
│ Bruno v4 Live: AI, Scripting,   │
│ Docs & What's New               │
│ 11:00 AM EDT / 4:00 PM BST      │
│ [ Register free → ]             │
└─────────────────────────────────┘
```

**Under 640px** — collapses to a slim bar on the bottom edge. Title and time drop out, wording shortens to fit down to 320px, and `env(safe-area-inset-bottom)` keeps it clear of the iPhone home indicator:

```
┌──────────────────────────────────────────────┐
│ ● V4 WEBINAR · AUG 19      [Register →]  [×] │
└──────────────────────────────────────────────┘
```

## Notes

- **Self-retiring** — the script no-ops after `2026-08-19T16:00:00Z` (webinar end), so nothing breaks if we forget to remove it. The file can be deleted after that date.
- Dismissal persists via `localStorage`, wrapped in `try/catch` so blocked storage degrades to "shows every visit" rather than throwing.
- Light and dark themes both styled; `dark` is set on `<html>`, which the selectors target.
- **Stays clear of the AI assistant.** The assistant panel is an in-flow sibling that squeezes the content column, and Mintlify publishes its width as `--assistant-sheet-width` on `<html>`, which its own fixed navbar subtracts. The card does the same in `right`/`max-width`, so it slides aside as the panel opens and resizes instead of covering the chat input.
- Below 1024px the assistant is a bottom drawer rather than a side panel, which the mobile bar would sit on top of, so the card hides whenever an open Radix dialog is present — that covers search and mobile nav too.
- The assistant is gated on chat permissions, so it never renders in `mint dev`; this behavior can only be verified on a deployed build.

## Testing

Verified against `mint dev`: light/dark, desktop and mobile widths, dismiss + reload persistence.

⚠️ Note that `mint dev` does **not** inject root-level custom scripts — `reo.js` is absent locally too, while production HTML does include it. To preview locally, load a page and run:

```js
document.body.appendChild(Object.assign(document.createElement('script'), { src: '/webinar-card.js' }))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
