### PR TITLE
Experiment: product-oriented navigation + denser layout

### DIFF
--- a/advanced-guides/visualize.mdx
+++ b/advanced-guides/visualize.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Response Visualization"
-sidebarTitle: "Visualizer"
+sidebarTitle: "Visualize Responses"
 ---
 
 import { BrunoButton } from "/snippets/BrunoButton.jsx";

--- a/docs.json
+++ b/docs.json
@@ -16,461 +16,478 @@
         "tag": "Latest",
         "groups": [
           {
-            "group": "Getting Started",
-            "icon": "rocket",
+            "group": "Documentation",
             "pages": [
               {
-                "group": "Introduction",
+                "group": "Getting Started",
+                "icon": "rocket",
                 "pages": [
-                  "introduction/getting-started",
-                  "introduction/quick-start",
-                  "get-started/bruno-basics/download",
-                  "introduction/manifesto",
-                  "introduction/feedback-community"
-                ]
-              },
-              {
-                "group": "Bruno Basics",
-                "pages": [
-                  "get-started/bruno-basics/create-a-workspace",
-                  "get-started/bruno-basics/create-a-collection",
-                  "get-started/bruno-basics/create-a-folder",
-                  "get-started/bruno-basics/create-a-request",
-                  "get-started/bruno-basics/create-a-test",
-                  "get-started/bruno-basics/run-a-collection"
-                ]
-              },
-              {
-                "group": "Import or Export Data",
-                "pages": [
-                  "get-started/import-export-data/import-collections",
-                  "get-started/import-export-data/export-collections",
-                  "get-started/import-export-data/import-export-workspace",
-                  "get-started/import-export-data/import-export-environments",
-                  "get-started/import-export-data/postman-migration",
-                  "get-started/import-export-data/script-translator"
-                ]
-              },
-              {
-                "group": "Configure",
-                "pages": [
-                  "get-started/configure/settings",
-                  "get-started/configure/keybindings",
-                  "get-started/configure/proxy-config",
-                  "get-started/configure/javascript-sandbox"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Core Features",
-            "icon": "zap",
-            "pages": [
-              {
-                "group": "Send Requests",
-                "pages": [
-                  "send-requests/overview",
                   {
-                    "group": "REST",
+                    "group": "Introduction",
                     "pages": [
-                      "send-requests/REST/overview",
-                      "send-requests/REST/rest-api",
-                      "send-requests/REST/req-header",
-                      "send-requests/REST/parameters",
-                      "send-requests/REST/body-data",
-                      "send-requests/REST/request-settings",
-                      "send-requests/REST/code-generator"
+                      "introduction/getting-started",
+                      "introduction/quick-start",
+                      "get-started/bruno-basics/download",
+                      "introduction/manifesto",
+                      "introduction/feedback-community"
                     ]
                   },
                   {
-                    "group": "GraphQL",
+                    "group": "Bruno Basics",
                     "pages": [
-                      "send-requests/graphql/overview",
-                      "send-requests/graphql/graphql-api",
-                      "send-requests/graphql/graphql-variables",
-                      "send-requests/graphql/query-builder"
-                    ]
-                  },
-                  {
-                    "group": "gRPC",
-                    "pages": [
-                      "send-requests/grpc/overview",
-                      "send-requests/grpc/grpc-request",
-                      "send-requests/grpc/grpc-proto",
-                      "send-requests/grpc/grpc-streams"
-                    ]
-                  },
-                  {
-                    "group": "WebSocket",
-                    "pages": [
-                      "send-requests/websocket/overview",
-                      "send-requests/websocket/ws-interface",
-                      "send-requests/websocket/create-request",
-                      "send-requests/websocket/message-types"
-                    ]
-                  },
-                  {
-                    "group": "SOAP",
-                    "pages": [
-                      "send-requests/soap/soap-request"
-                    ]
-                  },
-                  {
-                    "group": "Response Data & Cookies",
-                    "pages": [
-                      "send-requests/res-data-cookies/overview",
-                      "send-requests/res-data-cookies/res-data",
-                      "send-requests/res-data-cookies/cookies",
-                      "send-requests/res-data-cookies/response-examples"
-                    ]
-                  },
-                  "send-requests/history"
-                ]
-              },
-              {
-                "group": "Variables",
-                "pages": [
-                  "variables/overview",
-                  "variables/environment-variables",
-                  "variables/global-environment-variables",
-                  "variables/collection-variables",
-                  "variables/folder-variables",
-                  "variables/request-variables",
-                  "variables/runtime-variables",
-                  "variables/prompt-variables",
-                  "variables/process-env",
-                  "variables/interpolation"
-                ]
-              },
-              {
-                "group": "Git Integration & Collaboration",
-                "pages": [
-                  "git-integration/overview",
-                  "git-integration/git-strategies",
-                  {
-                    "group": "Using GUI",
-                    "pages": [
-                      "git-integration/using-gui/intro",
-                      "git-integration/using-gui/provider",
-                      "git-integration/using-gui/consumer"
-                    ]
-                  },
-                  "git-integration/using-cli",
-                  "git-integration/gitlab",
-                  "git-integration/bitbucket",
-                  "git-integration/azure-devops",
-                  "git-integration/embed-bruno-collection"
-                ]
-              },
-              {
-                "group": "Git Providers",
-                "pages": [
-                  "git-providers/overview",
-                  "git-providers/github"
-                ]
-              },
-              {
-                "group": "Tests and Scripts",
-                "pages": [
-                  {
-                    "group": "Tests",
-                    "pages": [
-                      "testing/tests/introduction",
-                      "testing/tests/assertions"
-                    ]
-                  },
-                  {
-                    "group": "Scripts",
-                    "pages": [
-                      "testing/script/getting-started",
-                      "testing/script/javascript-reference",
-                      "testing/script/script-flow",
-                      "testing/script/inbuilt-libraries",
-                      "testing/script/external-libraries",
-                      "testing/script/js-file",
-                      "testing/script/dynamic-variables",
-                      "testing/script/request-chaining",
-                      {
-                        "group": "Request",
-                        "pages": [
-                          "testing/script/request/request-object",
-                          "testing/script/request/sync-requests"
-                        ]
-                      },
-                      {
-                        "group": "Response",
-                        "pages": [
-                          "testing/script/response/response-object",
-                          "testing/script/response/response-query"
-                        ]
-                      },
-                      "testing/script/vars"
-                    ]
-                  },
-                  {
-                    "group": "Automate Tests",
-                    "pages": [
-                      "testing/automate-test/overview",
-                      "testing/automate-test/manual-test",
-                      "testing/automate-test/automate-test",
-                      "testing/automate-test/data-driven-testing"
+                      "get-started/bruno-basics/create-a-workspace",
+                      "get-started/bruno-basics/create-a-collection",
+                      "get-started/bruno-basics/create-a-folder",
+                      "get-started/bruno-basics/create-a-request",
+                      "get-started/bruno-basics/create-a-test",
+                      "get-started/bruno-basics/run-a-collection"
                     ]
                   }
-                ]
+                ],
+                "expanded": true
               },
               {
-                "group": "Secret Management",
+                "group": "Tools",
+                "icon": "wrench",
                 "pages": [
-                  "secrets-management/overview",
-                  "secrets-management/secret-variables",
-                  "secrets-management/secret-masking",
-                  "secrets-management/dotenv-file",
                   {
-                    "group": "Secret Managers",
+                    "group": "API Client",
                     "pages": [
-                      "secrets-management/secret-managers/overview",
-                      "secrets-management/secret-managers/migration",
                       {
-                        "group": "HashiCorp Vault",
+                        "group": "Send Requests",
                         "pages": [
-                          "secrets-management/secret-managers/hashicorp-vault/overview",
-                          "secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider",
-                          "secrets-management/secret-managers/hashicorp-vault/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/hashicorp-vault/using-secrets"                        
+                          "send-requests/overview",
+                          {
+                            "group": "REST",
+                            "pages": [
+                              "send-requests/REST/overview",
+                              "send-requests/REST/rest-api",
+                              "send-requests/REST/req-header",
+                              "send-requests/REST/parameters",
+                              "send-requests/REST/body-data",
+                              "send-requests/REST/request-settings",
+                              "send-requests/REST/code-generator"
+                            ]
+                          },
+                          {
+                            "group": "GraphQL",
+                            "pages": [
+                              "send-requests/graphql/overview",
+                              "send-requests/graphql/graphql-api",
+                              "send-requests/graphql/graphql-variables",
+                              "send-requests/graphql/query-builder"
+                            ]
+                          },
+                          {
+                            "group": "gRPC",
+                            "pages": [
+                              "send-requests/grpc/overview",
+                              "send-requests/grpc/grpc-request",
+                              "send-requests/grpc/grpc-proto",
+                              "send-requests/grpc/grpc-streams"
+                            ]
+                          },
+                          {
+                            "group": "WebSocket",
+                            "pages": [
+                              "send-requests/websocket/overview",
+                              "send-requests/websocket/ws-interface",
+                              "send-requests/websocket/create-request",
+                              "send-requests/websocket/message-types"
+                            ]
+                          },
+                          {
+                            "group": "SOAP",
+                            "pages": [
+                              "send-requests/soap/soap-request"
+                            ]
+                          },
+                          {
+                            "group": "Response Data & Cookies",
+                            "pages": [
+                              "send-requests/res-data-cookies/overview",
+                              "send-requests/res-data-cookies/res-data",
+                              "send-requests/res-data-cookies/cookies",
+                              "send-requests/res-data-cookies/response-examples",
+                              "advanced-guides/visualize"
+                            ]
+                          },
+                          "send-requests/history"
                         ]
                       },
                       {
-                        "group": "AWS Secrets Manager",
+                        "group": "Variables",
                         "pages": [
-                          "secrets-management/secret-managers/aws-secrets-manager/overview",
-                          "secrets-management/secret-managers/aws-secrets-manager/adding-a-secret-provider",
-                          "secrets-management/secret-managers/aws-secrets-manager/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/aws-secrets-manager/using-secrets"
+                          "variables/overview",
+                          "variables/environment-variables",
+                          "variables/global-environment-variables",
+                          "variables/collection-variables",
+                          "variables/folder-variables",
+                          "variables/request-variables",
+                          "variables/runtime-variables",
+                          "variables/prompt-variables",
+                          "variables/process-env",
+                          "variables/interpolation"
                         ]
                       },
                       {
-                        "group": "Azure Key Vault",
+                        "group": "Tests and Scripts",
                         "pages": [
-                          "secrets-management/secret-managers/azure-key-vault/overview",
-                          "secrets-management/secret-managers/azure-key-vault/adding-a-secret-provider",
-                          "secrets-management/secret-managers/azure-key-vault/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/azure-key-vault/using-secrets",
-                          "secrets-management/secret-managers/azure-key-vault/cli-authentication"
+                          {
+                            "group": "Tests",
+                            "pages": [
+                              "testing/tests/introduction",
+                              "testing/tests/assertions"
+                            ]
+                          },
+                          {
+                            "group": "Scripts",
+                            "pages": [
+                              "testing/script/getting-started",
+                              "testing/script/javascript-reference",
+                              "testing/script/script-flow",
+                              "testing/script/inbuilt-libraries",
+                              "testing/script/external-libraries",
+                              "testing/script/js-file",
+                              "testing/script/dynamic-variables",
+                              "testing/script/request-chaining",
+                              {
+                                "group": "Request",
+                                "pages": [
+                                  "testing/script/request/request-object",
+                                  "testing/script/request/sync-requests"
+                                ]
+                              },
+                              {
+                                "group": "Response",
+                                "pages": [
+                                  "testing/script/response/response-object",
+                                  "testing/script/response/response-query"
+                                ]
+                              },
+                              "testing/script/vars"
+                            ]
+                          },
+                          {
+                            "group": "Automate Tests",
+                            "pages": [
+                              "testing/automate-test/overview",
+                              "testing/automate-test/manual-test",
+                              "testing/automate-test/automate-test",
+                              "testing/automate-test/data-driven-testing"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Authentication & Authorization",
+                        "pages": [
+                          "auth/overview",
+                          "auth/basic",
+                          "auth/bearer",
+                          "auth/digest",
+                          "auth/aws-signature",
+                          "auth/ntlm",
+                          "auth/oauth1",
+                          "auth/akamai-edgegrid",
+                          {
+                            "group": "OAuth 2.0",
+                            "pages": [
+                              "auth/oauth2-2.0/overview",
+                              "auth/oauth2-2.0/collection-level-configuration",
+                              "auth/oauth2-2.0/authorization-code",
+                              "auth/oauth2-2.0/client-credentials",
+                              "auth/oauth2-2.0/password-credentials",
+                              "auth/oauth2-2.0/system-browser"
+                            ]
+                          },
+                          "auth/add-and-manage-certs"
+                        ]
+                      },
+                      {
+                        "group": "Secret Management",
+                        "pages": [
+                          "secrets-management/overview",
+                          "secrets-management/secret-variables",
+                          "secrets-management/secret-masking",
+                          "secrets-management/dotenv-file",
+                          {
+                            "group": "Secret Managers",
+                            "pages": [
+                              "secrets-management/secret-managers/overview",
+                              "secrets-management/secret-managers/migration",
+                              {
+                                "group": "HashiCorp Vault",
+                                "pages": [
+                                  "secrets-management/secret-managers/hashicorp-vault/overview",
+                                  "secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider",
+                                  "secrets-management/secret-managers/hashicorp-vault/configuring-and-fetching-secrets",
+                                  "secrets-management/secret-managers/hashicorp-vault/using-secrets"
+                                ]
+                              },
+                              {
+                                "group": "AWS Secrets Manager",
+                                "pages": [
+                                  "secrets-management/secret-managers/aws-secrets-manager/overview",
+                                  "secrets-management/secret-managers/aws-secrets-manager/adding-a-secret-provider",
+                                  "secrets-management/secret-managers/aws-secrets-manager/configuring-and-fetching-secrets",
+                                  "secrets-management/secret-managers/aws-secrets-manager/using-secrets"
+                                ]
+                              },
+                              {
+                                "group": "Azure Key Vault",
+                                "pages": [
+                                  "secrets-management/secret-managers/azure-key-vault/overview",
+                                  "secrets-management/secret-managers/azure-key-vault/adding-a-secret-provider",
+                                  "secrets-management/secret-managers/azure-key-vault/configuring-and-fetching-secrets",
+                                  "secrets-management/secret-managers/azure-key-vault/using-secrets",
+                                  "secrets-management/secret-managers/azure-key-vault/cli-authentication"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "group": "Debugging",
+                        "pages": [
+                          "debugging/timeline",
+                          "debugging/dev-tools"
+                        ]
+                      },
+                      {
+                        "group": "Import or Export Data",
+                        "pages": [
+                          "get-started/import-export-data/import-collections",
+                          "get-started/import-export-data/export-collections",
+                          "get-started/import-export-data/import-export-workspace",
+                          "get-started/import-export-data/import-export-environments",
+                          "get-started/import-export-data/postman-migration",
+                          "get-started/import-export-data/script-translator"
+                        ]
+                      },
+                      {
+                        "group": "Configure",
+                        "pages": [
+                          "get-started/configure/settings",
+                          "get-started/configure/keybindings",
+                          "get-started/configure/proxy-config",
+                          "get-started/configure/javascript-sandbox"
                         ]
                       }
                     ]
+                  },
+                  {
+                    "group": "Bruno CLI",
+                    "pages": [
+                      "bru-cli/overview",
+                      "bru-cli/quick-start",
+                      "bru-cli/installation",
+                      "bru-cli/commandOptions",
+                      "bru-cli/runCollection",
+                      "bru-cli/builtInReporters",
+                      "bru-cli/import",
+                      "bru-cli/proxyConfiguration",
+                      "bru-cli/secret-managers"
+                    ]
+                  },
+                  {
+                    "group": "VS Code Extension",
+                    "pages": [
+                      "vs-code-extension/overview",
+                      "vs-code-extension/install-config",
+                      "vs-code-extension/send-req"
+                    ]
+                  },
+                  {
+                    "group": "API Docs",
+                    "pages": [
+                      "api-docs/overview",
+                      "api-docs/workspace-docs",
+                      "api-docs/collection-docs",
+                      "api-docs/folder-docs",
+                      "api-docs/request-docs",
+                      "api-docs/auto-generate-docs"
+                    ]
+                  }
+                ],
+                "expanded": true
+              },
+              {
+                "group": "Collaboration",
+                "icon": "users",
+                "pages": [
+                  {
+                    "group": "Git Integration & Collaboration",
+                    "pages": [
+                      "git-integration/overview",
+                      "git-integration/git-strategies",
+                      {
+                        "group": "Using GUI",
+                        "pages": [
+                          "git-integration/using-gui/intro",
+                          "git-integration/using-gui/provider",
+                          "git-integration/using-gui/consumer"
+                        ]
+                      },
+                      "git-integration/using-cli",
+                      "git-integration/gitlab",
+                      "git-integration/bitbucket",
+                      "git-integration/azure-devops",
+                      "git-integration/embed-bruno-collection"
+                    ]
+                  },
+                  {
+                    "group": "Git Providers",
+                    "pages": [
+                      "git-providers/overview",
+                      "git-providers/github"
+                    ]
                   }
                 ]
               },
               {
-                "group": "Authentication & Authorization",
+                "group": "Integrations",
+                "icon": "plug",
                 "pages": [
-                  "auth/overview",
-                  "auth/basic",
-                  "auth/bearer",
-                  "auth/digest",
-                  "auth/aws-signature",
-                  "auth/ntlm",
-                  "auth/oauth1",
-                  "auth/akamai-edgegrid",
                   {
-                    "group": "OAuth 2.0",
+                    "group": "CI/CD & Containers",
                     "pages": [
-                      "auth/oauth2-2.0/overview",
-                      "auth/oauth2-2.0/collection-level-configuration",
-                      "auth/oauth2-2.0/authorization-code",
-                      "auth/oauth2-2.0/client-credentials",
-                      "auth/oauth2-2.0/password-credentials",
-                      "auth/oauth2-2.0/system-browser"
+                      "bru-cli/docker",
+                      {
+                        "group": "GitHub Actions",
+                        "pages": [
+                          "bru-cli/github-actions/overview",
+                          "bru-cli/github-actions/downstream-actions",
+                          "bru-cli/github-actions/manual-setup"
+                        ]
+                      },
+                      "bru-cli/jenkins"
                     ]
                   },
-                  "auth/add-and-manage-certs"
-                ]
-              },
-              {
-                "group": "Debugging",
-                "pages": [
-                  "debugging/timeline",
-                  "debugging/dev-tools"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "API Tools",
-            "icon": "book-open",
-            "pages": [
-              {
-                "group": "Create Documentation",
-                "pages": [
-                  "api-docs/overview",
-                  "api-docs/workspace-docs",
-                  "api-docs/collection-docs",
-                  "api-docs/folder-docs",
-                  "api-docs/request-docs",
-                  "api-docs/auto-generate-docs"
-                ]
-              },
-              {
-                "group": "OpenAPI",
-                "pages": [
-                  "open-api/overview",
-                  "open-api/importOAS",
-                  "open-api/exportOAS",
-                  "open-api/createOAS",
-                  "open-api/openapi-sync"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Developer Tools",
-            "icon": "code",
-            "pages": [
-              {
-                "group": "AI",
-                "tag": "Beta",
-                "pages": [
                   {
-                    "group": "Bruno AI",
+                    "group": "AI",
                     "tag": "Beta",
                     "pages": [
-                      "ai/bruno-ai/introduction",
-                      "ai/bruno-ai/configuration",
-                      "ai/bruno-ai/usage"
+                      {
+                        "group": "Bruno AI",
+                        "tag": "Beta",
+                        "pages": [
+                          "ai/bruno-ai/introduction",
+                          "ai/bruno-ai/configuration",
+                          "ai/bruno-ai/usage"
+                        ]
+                      },
+                      {
+                        "group": "Integration",
+                        "pages": [
+                          "ai/integration/overview",
+                          "ai/integration/use-cases",
+                          "ai/integration/cursor",
+                          "ai/integration/vs-code",
+                          "ai/integration/codex",
+                          "ai/integration/claude",
+                          "ai/integration/devin"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "group": "Integration",
+                    "group": "Apps",
                     "pages": [
-                      "ai/integration/overview",
-                      "ai/integration/use-cases",
-                      "ai/integration/cursor",
-                      "ai/integration/vs-code",
-                      "ai/integration/codex",
-                      "ai/integration/claude",
-                      "ai/integration/devin"
+                      "apps/overview",
+                      "apps/configure",
+                      "apps/ai-with-apps",
+                      "apps/api-ref",
+                      "apps/examples"
                     ]
                   }
                 ]
               },
               {
-                "group": "Apps",
+                "group": "Reference",
+                "icon": "book-open",
                 "pages": [
-                  "apps/overview",
-                  "apps/configure",
-                  "apps/ai-with-apps",
-                  "apps/api-ref",
-                  "apps/examples"
-                ]
-              },
-              {
-                "group": "Bruno CLI",
-                "pages": [
-                  "bru-cli/overview",
-                  "bru-cli/quick-start",
-                  "bru-cli/installation",
-                  "bru-cli/commandOptions",
-                  "bru-cli/runCollection",
-                  "bru-cli/builtInReporters",
-                  "bru-cli/import",
-                  "bru-cli/proxyConfiguration",
-                  "bru-cli/secret-managers",
-                  "bru-cli/docker",
                   {
-                    "group": "GitHub Actions",
+                    "group": "Bru Lang",
                     "pages": [
-                      "bru-cli/github-actions/overview",
-                      "bru-cli/github-actions/downstream-actions",
-                      "bru-cli/github-actions/manual-setup"
+                      "bru-lang/overview",
+                      "bru-lang/language",
+                      "bru-lang/tag-reference",
+                      "bru-lang/samples",
+                      "bru-lang/syntax-highlighting"
                     ]
                   },
-                  "bru-cli/jenkins"
+                  {
+                    "group": "OpenCollection YAML",
+                    "pages": [
+                      "opencollection-yaml/overview",
+                      "opencollection-yaml/samples",
+                      "opencollection-yaml/structure-reference"
+                    ]
+                  },
+                  {
+                    "group": "OpenAPI",
+                    "pages": [
+                      "open-api/overview",
+                      "open-api/importOAS",
+                      "open-api/exportOAS",
+                      "open-api/createOAS",
+                      "open-api/openapi-sync"
+                    ]
+                  },
+                  {
+                    "group": "Converters",
+                    "pages": [
+                      "converters/overview",
+                      "converters/postman-to-bruno",
+                      "converters/insomnia-to-bruno",
+                      "converters/openapi-to-bruno",
+                      "converters/wsdl-to-bruno"
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Bru Lang",
+                "group": "License Management",
+                "icon": "key",
                 "pages": [
-                  "bru-lang/overview",
-                  "bru-lang/language",
-                  "bru-lang/tag-reference",
-                  "bru-lang/samples",
-                  "bru-lang/syntax-highlighting"
-                ]
-              },
-              {
-                "group": "OpenCollection YAML",
-                "pages": [
-                  "opencollection-yaml/overview",
-                  "opencollection-yaml/samples",
-                  "opencollection-yaml/structure-reference"
-                ]
-              },
-              {
-                "group": "Converters",
-                "pages": [
-                  "converters/overview",
-                  "converters/postman-to-bruno",
-                  "converters/insomnia-to-bruno",
-                  "converters/openapi-to-bruno",
-                  "converters/wsdl-to-bruno"
-                ]
-              },
-              {
-                "group": "VS Code Extension",
-                "pages": [
-                  "vs-code-extension/overview",
-                  "vs-code-extension/install-config",
-                  "vs-code-extension/send-req"
+                  "license-overview",
+                  {
+                    "group": "End Users",
+                    "pages": [
+                      "license-end-users/activate-license"
+                    ]
+                  },
+                  {
+                    "group": "License Administrators",
+                    "pages": [
+                      "license-administrators/license-portal",
+                      "license-administrators/billing",
+                      "license-administrators/self-hosted-licensing",
+                      {
+                        "group": "SAML SSO",
+                        "pages": [
+                          "license-administrators/saml-sso/overview",
+                          "license-administrators/saml-sso/configure-saml-sso-with-okta",
+                          "license-administrators/saml-sso/configure-saml-sso-with-entra-id",
+                          "license-administrators/saml-sso/troubleshooting"
+                        ]
+                      },
+                      {
+                        "group": "SCIM Provisioning",
+                        "pages": [
+                          "license-administrators/scim-provisioning/overview",
+                          "license-administrators/scim-provisioning/configure-scim-with-okta",
+                          "license-administrators/scim-provisioning/configure-scim-with-entra-id",
+                          "license-administrators/scim-provisioning/bruno-scim-api"
+                        ]
+                      },
+                      "license-administrators/ai-policy"
+                    ]
+                  }
                 ]
               }
-            ]
-          },
-          {
-            "group": "License Management",
-            "icon": "key",
-            "pages": [
-              "license-overview",
-              {
-                "group": "End Users",
-                "pages": [
-                  "license-end-users/activate-license"
-                ]
-              },
-              {
-                "group": "License Administrators",
-                "pages": [
-                  "license-administrators/license-portal",
-                  "license-administrators/billing",
-                  "license-administrators/self-hosted-licensing",
-                  {
-                    "group": "SAML SSO",
-                    "pages": [
-                      "license-administrators/saml-sso/overview",
-                      "license-administrators/saml-sso/configure-saml-sso-with-okta",
-                      "license-administrators/saml-sso/configure-saml-sso-with-entra-id",
-                      "license-administrators/saml-sso/troubleshooting"
-                    ]
-                  },
-                  {
-                    "group": "SCIM Provisioning",
-                    "pages": [
-                      "license-administrators/scim-provisioning/overview",
-                      "license-administrators/scim-provisioning/configure-scim-with-okta",
-                      "license-administrators/scim-provisioning/configure-scim-with-entra-id",
-                      "license-administrators/scim-provisioning/bruno-scim-api"
-                    ]
-                  },
-                  "license-administrators/ai-policy"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Advanced Guides",
-            "icon": "graduation-cap",
-            "pages": [
-              "advanced-guides/visualize"
             ]
           }
         ]

--- a/style.css
+++ b/style.css
@@ -1,0 +1,144 @@
+/* ===================================================================
+   Density pass (prototype) — tighter type, spacing, and media so more
+   content fits per screen. Scoped to documented Mintlify ids where
+   possible. Body text drops 16px -> 14.5px; because the prose theme
+   sizes headings and margins in em, most spacing scales down with it.
+   =================================================================== */
+
+/* --- Article body ------------------------------------------------- */
+#content-area .mdx-content {
+  font-size: 0.90625rem; /* 14.5px */
+  line-height: 1.55;
+  margin-top: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+/* Headings: keep hierarchy but trim the air above them */
+#content-area .mdx-content h1 {
+  margin-bottom: 0.6em;
+}
+#content-area .mdx-content h2 {
+  margin-top: 1.5em;
+  margin-bottom: 0.6em;
+}
+#content-area .mdx-content h3 {
+  margin-top: 1.25em;
+  margin-bottom: 0.5em;
+}
+
+#content-area .mdx-content p,
+#content-area .mdx-content ul,
+#content-area .mdx-content ol {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+#content-area .mdx-content li {
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
+}
+
+/* --- Screenshots: cap size so images illustrate, not dominate ----- */
+#content-area .mdx-content img {
+  max-width: min(100%, 580px);
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+/* --- Callouts: less padding, tighter internal text ---------------- */
+#content-area div:has(> [data-component-part="callout-icon"]) {
+  padding: 0.625rem 0.875rem;
+}
+[data-component-part="callout-content"] {
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+/* --- Full-width layout --------------------------------------------
+   Navbar, sidebar, content, and TOC all share one centered 88rem
+   frame; releasing it lets the sidebar sit at the viewport's left
+   edge. The navbar search lives in a flex-1 wrapper that would grow
+   with it, so cap the search entry at a fixed width. Prose stays at
+   a readable measure. */
+.max-w-8xl {
+  max-width: none;
+}
+/* The body wrapper (sidebar + content) is capped separately via a
+   conditional utility class, so release it too — this is the cap
+   that actually constrains the page content. */
+div[class*="peer-[.is-not-center]:max-w-8xl"] {
+  max-width: none !important;
+}
+#search-bar-entry {
+  max-width: 26rem;
+}
+/* Center the article in the space between sidebar and TOC: cap the
+   title header, body, pagination, and footer at a shared width and
+   auto-center them as a unit. The width is the dial — raise it for
+   denser pages, lower it for a narrower reading column. */
+#content-area > #header,
+#content-area > .mdx-content,
+#content-area > #pagination,
+#content-area > #footer {
+  max-width: 70rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* The box the article centers in is asymmetric (TOC reserves ~28rem
+   on the right vs ~21rem of sidebar on the left), so true "centered"
+   needs a rightward nudge on wide screens. Adjust the 3rem to taste. */
+@media (min-width: 1536px) {
+  #content-area > #header,
+  #content-area > .mdx-content,
+  #content-area > #pagination,
+  #content-area > #footer {
+    transform: translateX(3rem);
+  }
+}
+
+/* --- Sidebar: subtle tinted panel ---------------------------------- */
+#sidebar {
+  background: rgb(0 0 0 / 0.025);
+  border-right: 1px solid rgb(0 0 0 / 0.06);
+}
+.dark #sidebar {
+  background: rgb(255 255 255 / 0.025);
+  border-right: 1px solid rgb(255 255 255 / 0.07);
+}
+
+/* --- Hide the lone "Documentation" wrapper header -------------------
+   v4 needs a named top-level wrapper group (an empty name breaks
+   default-version routing), but its header is noise. When a version
+   has exactly one top-level group (v4), hide that group's header;
+   v3 has six groups, so :only-child never matches there. */
+#navigation-items > div:only-child > .sidebar-group-header {
+  display: none;
+}
+
+/* --- Sidebar section headers (Getting Started, Tools, ...) --------
+   Top-level sections render at indent 1rem; nested groups start at
+   1.75rem, so this selector only matches the section rows. */
+/* Match both style serializations: the server renders
+   "padding-left:1rem" but client-side re-renders write
+   "padding-left: 1rem" (with a space). Neither matches 1.75rem+,
+   so deeper groups stay regular weight. */
+#sidebar-content button[style*="padding-left:1rem"],
+#sidebar-content button[style*="padding-left: 1rem"] {
+  font-weight: 600;
+  color: rgb(31 41 55);
+}
+.dark #sidebar-content button[style*="padding-left:1rem"],
+.dark #sidebar-content button[style*="padding-left: 1rem"] {
+  color: rgb(209 213 219);
+}
+
+/* --- Sidebar: smaller type, tighter rows --------------------------- */
+#sidebar-content {
+  font-size: 0.8125rem; /* 13px */
+}
+#sidebar-content li > a,
+#sidebar-content li > div {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+

--- a/testing/tests/introduction.mdx
+++ b/testing/tests/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Testing"
-sidebarTitle: "Introduction"
+sidebarTitle: "Writing Tests"
 ---
 
 <Warning>


### PR DESCRIPTION
## What this is

A **prototype for discussion, not ready to merge** — exploring how the docs could be laid out to reflect the product suite (API Client, CLI, VS Code Extension, API Docs), plus a density/layout pass responding to feedback that the site doesn't use space well.

Best reviewed by clicking around the Mintlify preview deployment rather than reading the diff.

## Navigation (v4 only, page URLs unchanged)

- Sidebar reorganized into collapsible sections: **Getting Started, Tools, Collaboration, Integrations, Reference, License Management**
- **Tools** mirrors the product suite: API Client, Bruno CLI, VS Code Extension, API Docs. The API Client section absorbs the feature groups (Send Requests, Variables, Tests and Scripts, Auth, Secrets, Debugging)
- Docker / GitHub Actions / Jenkins moved from under the CLI to **Integrations**; Bru Lang, OpenCollection YAML, OpenAPI, Converters grouped under **Reference**
- Sections sit inside a wrapper group ("Documentation") whose header is hidden via CSS — Mintlify requires a named top-level group (an empty name breaks default-version routing), but only nested groups are collapsible
- Getting Started and Tools start expanded; everything else starts collapsed
- Visualizer moved under Response Data & Cookies as "Visualize Responses" (file not moved yet — would need a redirect before merging); Advanced Guides section removed; tests intro renamed "Writing Tests"

## Layout & density (`style.css`)

- Body text 16px → 14.5px, tighter line-height and heading/paragraph margins; screenshots capped at 580px; compact sidebar
- Full-width layout: sidebar at the viewport's left edge, content column centered between sidebar and TOC at 70rem
- Sidebar tinted as a distinct panel; section headers bolded

## ⚠️ Scope caveats

- **`style.css` is global** — unlike the nav changes (v4-only), the CSS affects v3 pages and the entire site if merged
- The bolded-section-headers and hidden-wrapper-header rules depend on Mintlify DOM details (inline style values, `:only-child` structure) and could quietly stop applying after a Mintlify platform update — worth hardening before a real merge
- Mock Server has no docs yet; it has a natural home under Tools when content exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)