### PR TITLE
docs: restructure navigation around Bruno's products, and go full width

### DIFF
--- a/api-client/overview.mdx
+++ b/api-client/overview.mdx
@@ -1,0 +1,59 @@
+---
+title: "API Client"
+sidebarTitle: "Overview"
+---
+
+The Bruno API Client is the desktop application you use to build, send, and organize API requests. Collections live as plain text files on your filesystem, so you can version them with Git and review API changes like code.
+
+<CardGroup cols={2}>
+  <Card title="Send Requests" icon="paper-plane" href="/send-requests/overview">
+    Build and send REST, GraphQL, gRPC, WebSocket, and SOAP requests.
+  </Card>
+  <Card title="Variables" icon="brackets-curly" href="/variables/overview">
+    Reuse values across environments, collections, folders, and requests.
+  </Card>
+  <Card title="Authentication" icon="lock" href="/auth/overview">
+    Configure Basic, Bearer, OAuth 2.0, AWS Signature, and more.
+  </Card>
+  <Card title="Tests & Scripts" icon="code" href="/testing/tests/introduction">
+    Write assertions and pre-request or post-response scripts in JavaScript.
+  </Card>
+  <Card
+    title="Secret Management"
+    icon="key"
+    href="/secrets-management/overview"
+  >
+    Keep credentials out of version control with secret variables and vaults.
+  </Card>
+  <Card
+    title="Git & Collaboration"
+    icon="code-branch"
+    href="/git-integration/overview"
+  >
+    Share collections with your team through your existing Git workflow.
+  </Card>
+</CardGroup>
+
+## New to Bruno?
+
+Start with the [Bruno Starter Guide](/introduction/quick-start) for a hands-on walkthrough, or [download the app](/get-started/bruno-basics/download) if you have not installed it yet.
+
+## The rest of Bruno
+
+The API Client is one of four parts of Bruno. The others share the same collection format, so work you do in one carries over to the others.
+
+<CardGroup cols={3}>
+  <Card title="CLI" icon="terminal" href="/bru-cli/overview">
+    Run the same collections from the command line and in CI/CD.
+  </Card>
+  <Card title="API Docs" icon="book" href="/api-docs/overview">
+    Document your APIs and generate shareable documentation.
+  </Card>
+  <Card
+    title="VS Code Extension"
+    icon="code"
+    href="/vs-code-extension/overview"
+  >
+    Open and send requests without leaving your editor.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -14,11 +14,11 @@
         "version": "v4",
         "default": true,
         "tag": "Latest",
-        "groups": [
+        "tabs": [
           {
-            "group": "Getting Started",
+            "tab": "Get Started",
             "icon": "rocket",
-            "pages": [
+            "groups": [
               {
                 "group": "Introduction",
                 "pages": [
@@ -41,7 +41,7 @@
                 ]
               },
               {
-                "group": "Import or Export Data",
+                "group": "Import & Migrate",
                 "pages": [
                   "get-started/import-export-data/import-collections",
                   "get-started/import-export-data/export-collections",
@@ -50,22 +50,19 @@
                   "get-started/import-export-data/postman-migration",
                   "get-started/import-export-data/script-translator"
                 ]
-              },
-              {
-                "group": "Configure",
-                "pages": [
-                  "get-started/configure/settings",
-                  "get-started/configure/keybindings",
-                  "get-started/configure/proxy-config",
-                  "get-started/configure/javascript-sandbox"
-                ]
               }
             ]
           },
           {
-            "group": "Core Features",
-            "icon": "zap",
-            "pages": [
+            "tab": "API Client",
+            "icon": "app-window",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "api-client/overview"
+                ]
+              },
               {
                 "group": "Send Requests",
                 "pages": [
@@ -122,7 +119,8 @@
                       "send-requests/res-data-cookies/overview",
                       "send-requests/res-data-cookies/res-data",
                       "send-requests/res-data-cookies/cookies",
-                      "send-requests/res-data-cookies/response-examples"
+                      "send-requests/res-data-cookies/response-examples",
+                      "advanced-guides/visualize"
                     ]
                   },
                   "send-requests/history"
@@ -144,34 +142,76 @@
                 ]
               },
               {
-                "group": "Git Integration & Collaboration",
+                "group": "Authentication",
                 "pages": [
-                  "git-integration/overview",
-                  "git-integration/git-strategies",
+                  "auth/overview",
+                  "auth/basic",
+                  "auth/bearer",
+                  "auth/digest",
+                  "auth/aws-signature",
+                  "auth/ntlm",
+                  "auth/oauth1",
+                  "auth/akamai-edgegrid",
                   {
-                    "group": "Using GUI",
+                    "group": "OAuth 2.0",
                     "pages": [
-                      "git-integration/using-gui/intro",
-                      "git-integration/using-gui/provider",
-                      "git-integration/using-gui/consumer"
+                      "auth/oauth2-2.0/overview",
+                      "auth/oauth2-2.0/collection-level-configuration",
+                      "auth/oauth2-2.0/authorization-code",
+                      "auth/oauth2-2.0/client-credentials",
+                      "auth/oauth2-2.0/password-credentials",
+                      "auth/oauth2-2.0/system-browser"
                     ]
                   },
-                  "git-integration/using-cli",
-                  "git-integration/gitlab",
-                  "git-integration/bitbucket",
-                  "git-integration/azure-devops",
-                  "git-integration/embed-bruno-collection"
+                  "auth/add-and-manage-certs"
                 ]
               },
               {
-                "group": "Git Providers",
+                "group": "Secret Management",
                 "pages": [
-                  "git-providers/overview",
-                  "git-providers/github"
+                  "secrets-management/overview",
+                  "secrets-management/secret-variables",
+                  "secrets-management/secret-masking",
+                  "secrets-management/dotenv-file",
+                  {
+                    "group": "Secret Managers",
+                    "pages": [
+                      "secrets-management/secret-managers/overview",
+                      "secrets-management/secret-managers/migration",
+                      {
+                        "group": "HashiCorp Vault",
+                        "pages": [
+                          "secrets-management/secret-managers/hashicorp-vault/overview",
+                          "secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider",
+                          "secrets-management/secret-managers/hashicorp-vault/configuring-and-fetching-secrets",
+                          "secrets-management/secret-managers/hashicorp-vault/using-secrets"
+                        ]
+                      },
+                      {
+                        "group": "AWS Secrets Manager",
+                        "pages": [
+                          "secrets-management/secret-managers/aws-secrets-manager/overview",
+                          "secrets-management/secret-managers/aws-secrets-manager/adding-a-secret-provider",
+                          "secrets-management/secret-managers/aws-secrets-manager/configuring-and-fetching-secrets",
+                          "secrets-management/secret-managers/aws-secrets-manager/using-secrets"
+                        ]
+                      },
+                      {
+                        "group": "Azure Key Vault",
+                        "pages": [
+                          "secrets-management/secret-managers/azure-key-vault/overview",
+                          "secrets-management/secret-managers/azure-key-vault/adding-a-secret-provider",
+                          "secrets-management/secret-managers/azure-key-vault/configuring-and-fetching-secrets",
+                          "secrets-management/secret-managers/azure-key-vault/using-secrets",
+                          "secrets-management/secret-managers/azure-key-vault/cli-authentication"
+                        ]
+                      }
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Tests and Scripts",
+                "group": "Tests & Scripts",
                 "pages": [
                   {
                     "group": "Tests",
@@ -220,114 +260,32 @@
                 ]
               },
               {
-                "group": "Secret Management",
+                "group": "Git & Collaboration",
                 "pages": [
-                  "secrets-management/overview",
-                  "secrets-management/secret-variables",
-                  "secrets-management/secret-masking",
-                  "secrets-management/dotenv-file",
+                  "git-integration/overview",
+                  "git-integration/git-strategies",
                   {
-                    "group": "Secret Managers",
+                    "group": "Using GUI",
                     "pages": [
-                      "secrets-management/secret-managers/overview",
-                      "secrets-management/secret-managers/migration",
-                      {
-                        "group": "HashiCorp Vault",
-                        "pages": [
-                          "secrets-management/secret-managers/hashicorp-vault/overview",
-                          "secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider",
-                          "secrets-management/secret-managers/hashicorp-vault/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/hashicorp-vault/using-secrets"                        
-                        ]
-                      },
-                      {
-                        "group": "AWS Secrets Manager",
-                        "pages": [
-                          "secrets-management/secret-managers/aws-secrets-manager/overview",
-                          "secrets-management/secret-managers/aws-secrets-manager/adding-a-secret-provider",
-                          "secrets-management/secret-managers/aws-secrets-manager/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/aws-secrets-manager/using-secrets"
-                        ]
-                      },
-                      {
-                        "group": "Azure Key Vault",
-                        "pages": [
-                          "secrets-management/secret-managers/azure-key-vault/overview",
-                          "secrets-management/secret-managers/azure-key-vault/adding-a-secret-provider",
-                          "secrets-management/secret-managers/azure-key-vault/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/azure-key-vault/using-secrets",
-                          "secrets-management/secret-managers/azure-key-vault/cli-authentication"
-                        ]
-                      }
+                      "git-integration/using-gui/intro",
+                      "git-integration/using-gui/provider",
+                      "git-integration/using-gui/consumer"
+                    ]
+                  },
+                  "git-integration/using-cli",
+                  "git-integration/gitlab",
+                  "git-integration/bitbucket",
+                  "git-integration/azure-devops",
+                  "git-integration/embed-bruno-collection",
+                  {
+                    "group": "Git Providers",
+                    "pages": [
+                      "git-providers/overview",
+                      "git-providers/github"
                     ]
                   }
                 ]
               },
-              {
-                "group": "Authentication & Authorization",
-                "pages": [
-                  "auth/overview",
-                  "auth/basic",
-                  "auth/bearer",
-                  "auth/digest",
-                  "auth/aws-signature",
-                  "auth/ntlm",
-                  "auth/oauth1",
-                  "auth/akamai-edgegrid",
-                  {
-                    "group": "OAuth 2.0",
-                    "pages": [
-                      "auth/oauth2-2.0/overview",
-                      "auth/oauth2-2.0/collection-level-configuration",
-                      "auth/oauth2-2.0/authorization-code",
-                      "auth/oauth2-2.0/client-credentials",
-                      "auth/oauth2-2.0/password-credentials",
-                      "auth/oauth2-2.0/system-browser"
-                    ]
-                  },
-                  "auth/add-and-manage-certs"
-                ]
-              },
-              {
-                "group": "Debugging",
-                "pages": [
-                  "debugging/timeline",
-                  "debugging/dev-tools"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "API Tools",
-            "icon": "book-open",
-            "pages": [
-              {
-                "group": "Create Documentation",
-                "pages": [
-                  "api-docs/overview",
-                  "api-docs/workspace-docs",
-                  "api-docs/collection-docs",
-                  "api-docs/folder-docs",
-                  "api-docs/request-docs",
-                  "api-docs/auto-generate-docs"
-                ]
-              },
-              {
-                "group": "OpenAPI",
-                "pages": [
-                  "open-api/overview",
-                  "open-api/importOAS",
-                  "open-api/exportOAS",
-                  "open-api/createOAS",
-                  "open-api/openapi-sync"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Developer Tools",
-            "icon": "code",
-            "pages": [
               {
                 "group": "AI",
                 "tag": "Beta",
@@ -366,17 +324,54 @@
                 ]
               },
               {
-                "group": "Bruno CLI",
+                "group": "Settings",
+                "pages": [
+                  "get-started/configure/settings",
+                  "get-started/configure/keybindings",
+                  "get-started/configure/proxy-config",
+                  "get-started/configure/javascript-sandbox"
+                ]
+              },
+              {
+                "group": "Debugging",
+                "pages": [
+                  "debugging/timeline",
+                  "debugging/dev-tools"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "CLI",
+            "icon": "terminal",
+            "groups": [
+              {
+                "group": "Overview",
                 "pages": [
                   "bru-cli/overview",
                   "bru-cli/quick-start",
-                  "bru-cli/installation",
-                  "bru-cli/commandOptions",
+                  "bru-cli/installation"
+                ]
+              },
+              {
+                "group": "Run Collections",
+                "pages": [
                   "bru-cli/runCollection",
+                  "bru-cli/commandOptions",
                   "bru-cli/builtInReporters",
-                  "bru-cli/import",
+                  "bru-cli/import"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
                   "bru-cli/proxyConfiguration",
-                  "bru-cli/secret-managers",
+                  "bru-cli/secret-managers"
+                ]
+              },
+              {
+                "group": "CI/CD",
+                "pages": [
                   "bru-cli/docker",
                   {
                     "group": "GitHub Actions",
@@ -388,7 +383,49 @@
                   },
                   "bru-cli/jenkins"
                 ]
+              }
+            ]
+          },
+          {
+            "tab": "API Docs",
+            "icon": "book",
+            "groups": [
+              {
+                "group": "Create Documentation",
+                "pages": [
+                  "api-docs/overview",
+                  "api-docs/workspace-docs",
+                  "api-docs/collection-docs",
+                  "api-docs/folder-docs",
+                  "api-docs/request-docs",
+                  "api-docs/auto-generate-docs"
+                ]
               },
+              {
+                "group": "OpenAPI",
+                "pages": [
+                  "open-api/overview",
+                  "open-api/importOAS",
+                  "open-api/exportOAS",
+                  "open-api/createOAS",
+                  "open-api/openapi-sync"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "VS Code Extension",
+            "icon": "code",
+            "pages": [
+              "vs-code-extension/overview",
+              "vs-code-extension/install-config",
+              "vs-code-extension/send-req"
+            ]
+          },
+          {
+            "tab": "Reference",
+            "icon": "book-open",
+            "groups": [
               {
                 "group": "Bru Lang",
                 "pages": [
@@ -416,22 +453,19 @@
                   "converters/openapi-to-bruno",
                   "converters/wsdl-to-bruno"
                 ]
-              },
-              {
-                "group": "VS Code Extension",
-                "pages": [
-                  "vs-code-extension/overview",
-                  "vs-code-extension/install-config",
-                  "vs-code-extension/send-req"
-                ]
               }
             ]
           },
           {
-            "group": "License Management",
+            "tab": "Licensing",
             "icon": "key",
-            "pages": [
-              "license-overview",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "license-overview"
+                ]
+              },
               {
                 "group": "End Users",
                 "pages": [
@@ -439,7 +473,7 @@
                 ]
               },
               {
-                "group": "License Administrators",
+                "group": "Administrators",
                 "pages": [
                   "license-administrators/license-portal",
                   "license-administrators/billing",
@@ -465,13 +499,6 @@
                   "license-administrators/ai-policy"
                 ]
               }
-            ]
-          },
-          {
-            "group": "Advanced Guides",
-            "icon": "graduation-cap",
-            "pages": [
-              "advanced-guides/visualize"
             ]
           }
         ]

--- a/style.css
+++ b/style.css
@@ -1,0 +1,65 @@
+/* ---------------------------------------------------------------------------
+   Desktop nav tabs — spread across the full width of the bar
+   ---------------------------------------------------------------------------
+   Mintlify renders the tab row as `.nav-tabs` (display:flex, gap-x-6) inside a
+   full-width `px-12` wrapper. `.nav-tabs` is a flex item with `flex: 0 1 auto`,
+   so it shrink-wraps its content: at a 1440px viewport it measures 796px inside
+   1344px of available space, bunching the tabs on the left and leaving ~548px of
+   dead air on the right.
+
+   Fix: let `.nav-tabs` grow to fill its wrapper, then hand the free space to
+   `justify-content: space-between`. Each tab keeps its own text-sized width and
+   the leftover width is divided equally between the six gaps, so the separation
+   between every pair of tabs is identical. The first and last tabs stay flush
+   with the bar's px-12 edges, which keeps "Get Started" aligned with the Bruno
+   wordmark on the left and the last tab aligned with the header controls on the
+   right.
+
+   Measured at 1440px: .nav-tabs 796.5px -> 1344px; the six inter-tab gaps go
+   from 24px each to 115.3px each. Ultra-wide is self-limiting — the navbar's own
+   max-w-8xl caps the row, so gaps top out around 121px rather than growing
+   without bound.
+
+   Notes:
+   - The underline indicator needs no CSS. It is a `w-full left-0` child of each
+     `<a>`, and since the anchors keep their intrinsic width, each indicator
+     still spans exactly its own tab box (icon + gap + label), unchanged from
+     today. It is *not* label-width — it has always been ~24px wider than the
+     text, most visibly under "CLI". Mintlify's active (`bg-primary`) and hover
+     (`group-hover:bg-gray-200`) colours are inherited untouched.
+   - The existing gap-x-6 (24px) is left in place on purpose. While there is free
+     space, space-between absorbs it and the result is identical with or without
+     the gap; once free space runs out the gap becomes a 24px minimum gutter,
+     which is the behaviour we want.
+   - No rules are applied to `.nav-tabs-item`, so the existing shrink/wrap
+     fallback is untouched: if the labels ever outgrow the bar, layout is
+     identical to today's. This rule is deliberately a no-op once free space runs
+     out — please keep it that way. Do NOT add `min-width: 0`, `overflow-x: auto`,
+     `flex: 0 0 auto` or per-item `padding-inline` here; each was tested and each
+     converts today's reachable shrink-and-wrap fallback into silently clipped or
+     hidden tabs at large browser font sizes.
+   - The 1024px breakpoint is px-based on purpose, to match Tailwind's compiled
+     `lg` screen (Tailwind's spacing is rem but its screens are px). Verified: the
+     wrapper flips from `display:none` to `display:flex` at exactly 1024px of
+     viewport width at root font sizes 12/16/20px. Do not "fix" this to 64rem —
+     that would drift against the browser's default-font-size setting.
+   - `div.nav-tabs.nav-tabs` is specificity (0,2,1). Nothing in Mintlify currently
+     declares `flex-grow` or `justify-content` on `.nav-tabs`, so a plain
+     `.nav-tabs` would win today; the doubled class is cheap insurance against a
+     future `justify-*` or `shrink-*` utility landing on this element.
+
+   Maintenance couplings:
+   - `.nav-tabs` is a Mintlify-emitted class, not a public API. If it is renamed,
+     this rule stops matching and the bar reverts to today's left-bunched layout
+     — a safe failure direction, but worth re-checking after a Mintlify bump.
+   - Gap size is a function of tab count and label widths, which are data in
+     docs.json (`navigation.versions[].tabs`). Reorganising the nav visibly
+     re-spaces this row; a nav of only 2-3 tabs would strand very large gaps.
+   --------------------------------------------------------------------------- */
+
+@media (min-width: 1024px) {
+  div.nav-tabs.nav-tabs {
+    flex: 1 1 auto;
+    justify-content: space-between;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -63,3 +63,102 @@
     justify-content: space-between;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Full-width docs shell — release Mintlify's 1472px cap
+   ---------------------------------------------------------------------------
+   Mintlify centres the entire shell — sidebar, article and table of contents —
+   inside a `max-w-8xl` (92rem = 1472px) box with `mx-auto`. Past that width the
+   box stops growing and the remainder becomes equal dead margins: 224px per
+   side at 1920px, 544px per side at 2560px. Nothing renders in them.
+
+   Two elements carry the cap, and both must be released or the shell tears in
+   half — the navbar would sit on a different grid from the body:
+     1. `header#navbar > div.max-w-8xl` — the navbar rail (wordmark, search,
+        header links, and the tab row above). Plain utility class, (0,1,0).
+     2. `header#navbar + div` — the wrapper around #sidebar, #content-area and
+        the TOC. Same 1472px, but written through Mintlify's per-page `mode`
+        peer variants, compiling to roughly
+          .peer-[…]:max-w-8xl:is(:where(.peer).is-not-custom ~ *)
+                              :is(:where(.peer).is-not-center ~ *)
+        which is (0,3,0).
+   `[class*="max-w-8xl"]` matches both — the bare utility and the peer variant
+   share that substring — with no coupling to where either sits in the tree, so
+   a Mintlify reshuffle cannot half-apply this. The selector is repeated three
+   times for (0,3,1), which clears carrier 2. That insurance is unused today:
+   Mintlify injects this file as an inline <style> inside <main>, unlayered and
+   last, and an unlayered declaration beats any @layer utilities rule regardless
+   of specificity. The repeats only matter if Mintlify layers custom CSS or
+   moves the injection point.
+
+   Why CSS: docs.json has no content-width option (`styling` accepts only
+   `eyebrows` and `codeblocks`). The only native escape hatches are per-page
+   frontmatter `mode: "custom"` (drops sidebar AND TOC) and `mode: "wide"`
+   (drops the TOC) — both remove chrome we want to keep, and would have to be
+   pasted into every .mdx file.
+
+   No media query, because none is needed: below the cap's binding width this
+   rule is a measured no-op. #sidebar, #content, the TOC, .nav-tabs and
+   #content-area are byte-identical with and without it at 390/768/1024/1280/
+   1440/1472 across seven pages. NB the cap is 92rem, so it tracks the root font
+   size — it binds at 1473px only at a 16px root, and at ~1105px at a 12px root.
+   The rule releases the cap exactly where the cap binds, whatever that width is.
+
+   Measured at 1920px on /send-requests/REST/rest-api:
+     #sidebar             x 256 -> 32     (still 18rem, still position:fixed)
+     article text        721px -> 1169px  (x 587 -> 363)
+     #table-of-contents   x 1400 -> 1624  (still 16.5rem)
+   Nothing inside the shell is touched — the sidebar's 18rem, the TOC's 16.5rem
+   and the gutter #content-area reserves for the fixed sidebar all still come
+   from Mintlify. Only the box around them grew, and #content-area (the single
+   flex-grow child) absorbs the new width. No horizontal overflow appears at any
+   width: documentElement.scrollWidth === innerWidth throughout.
+
+   Deliberate consequences, all measured — this rule caps nothing, so every
+   element keeps a single shared right edge. The capping variants that were
+   tried instead all scored worse: capping the content column strands the TOC
+   across a void of up to 1461px, and capping prose alone gives the page two
+   different right margins that read as a misalignment bug.
+   - Line length. Body copy goes 78 characters today -> 124 at 1920px, 198 at
+     2560px, 256 at 3440px, against a comfortable 45-90. At 3440 a lead
+     paragraph can render as one unbroken 256-character line. This is the real
+     cost of the change. If long measure becomes the complaint, the dial is a
+     max-width on `#content` — but expect the ragged-edge tradeoff above.
+   - Card grids are the weakest spot on very wide screens. Mintlify's `.columns`
+     uses a container query that tops out at 2 tracks, so cards inflate rather
+     than reflow: 352px each today -> 576px at 1920 (still good) -> 896px at
+     2560 -> 1336px at 3440, where a 3-card group shows two enormous cards and
+     an orphan.
+   - Nav tabs. The rule above spreads the row with space-between, and the cap
+     used to bound that row at 1376px so its gaps settled at ~121px. Uncapped,
+     the gaps track the viewport: 195px at 1920, 302px at 2560, 449px at 3440.
+     Left unbounded on purpose — every way of bounding it (a max-width on
+     .nav-tabs, or re-capping the navbar rail) puts back the dead margin this
+     rule removes, and does it asymmetrically, because the wordmark and header
+     links stay pinned to the viewport edges regardless.
+   - Images never upscale: Mintlify computes them to width:auto + max-width:100%,
+     so they render at natural width. Large screenshots therefore stop growing
+     and leave a trailing gutter on very wide screens (~209px at 3440). They do
+     not stretch or blur.
+   - The navbar search field grows with the rail: 443px -> 597px at 1920,
+     811px at 2560, 1104px at 3440.
+   - Narrow two-column tables and short code blocks span the full column and
+     leave a wide trailing gutter, which costs some scannability on reference
+     pages. Offset by a real win: code blocks that used to scroll horizontally
+     now fit.
+
+   Maintenance couplings:
+   - `max-w-8xl` is a Mintlify-emitted Tailwind class, not a public API. If it
+     is renamed or swapped for a custom property this rule stops matching and
+     the layout reverts to today's capped, centred shell — a safe failure
+     direction, but re-check after a Mintlify bump.
+   - Conversely, any future Mintlify <div> carrying an 8xl cap is uncapped too.
+     There are exactly two today, on every page and width tested. No .mdx in
+     this repo sets frontmatter `mode`, so every page renders is-not-custom /
+     is-not-center / is-not-wide / is-not-frame; there is no second layout
+     variant to check.
+   --------------------------------------------------------------------------- */
+
+div[class*="max-w-8xl"][class*="max-w-8xl"][class*="max-w-8xl"] {
+  max-width: none;
+}


### PR DESCRIPTION
> Supersedes #161 — identical branch (`542721c`), re-pushed to this repo instead of my fork so Mintlify can generate a preview deployment (the Mintlify app can't build against fork PRs).

> This is one alternative redesign/restructuring of the docs

## Why

Feedback was that the docs are hard to navigate — it isn't easy to find what you need from the sidebar, and it isn't easy to tell what the different parts of Bruno actually are.

The v4 sidebar was a single flat list of six generic buckets (Getting Started, Core Features, API Tools, Developer Tools, License Management, Advanced Guides) that mixed the products together. The CLI, the VS Code extension and the API documentation all lived under "Developer Tools" alongside Bru Lang and the converters.

## What changed

**1. Navigation restructured around Bruno's products** (`docs.json`)

Those buckets are replaced with Mintlify tabs, one per product:

`Get Started` | `API Client` | `CLI` | `API Docs` | `VS Code Extension` | `Reference` | `Licensing`

The four product tabs are the spine. The other three exist because the content has to live somewhere: **Get Started** is the cross-product onboarding path, **Reference** holds the genuinely shared material (Bru Lang, OpenCollection YAML, converters), and **Licensing** is orthogonal to all four. They're ordered so the four products read as a contiguous block.

Beyond the regrouping:

- **CLI** is promoted from a subgroup to a tab and resplit into Overview / Run Collections / Configuration / CI/CD (it was a 10-item flat list).
- "Git Providers" folds into "Git & Collaboration" — it was a two-page group sitting beside the real Git docs.
- `advanced-guides/visualize` is "Response Visualization", so it moves under Response Data & Cookies. That retires the one-page "Advanced Guides" group.
- `get-started/configure/*` becomes "Settings" under API Client.

One new page, `api-client/overview.mdx`, gives the API Client tab a landing page. It cross-links the other three products so each part of Bruno is discoverable from the others.

**No files were moved and no page paths changed**, so every existing URL still resolves and no redirects are needed.

**2. Nav tabs span the full header width** (`style.css`, new file)

The tab row is a shrink-to-fit flex container, so seven tabs bunched against the left gutter — at 1440px it measured 796px inside 1344px of available space. Letting it grow and distributing the slack with `justify-content: space-between` divides the leftover width into six identical gaps.

**3. The docs shell is full width** (`style.css`)

Mintlify centres the whole shell inside a `max-w-8xl` (1472px) box, leaving 224px of dead margin per side at 1920px and 544px at 2560px. Two elements carry that cap — the navbar rail and the wrapper around the sidebar/content/TOC — and both are released.

`docs.json` has no content-width option (`styling` accepts only `eyebrows` and `codeblocks`), and the native escape hatches are per-page frontmatter `mode: "custom"` / `"wide"`, which drop chrome we want and would need pasting into every `.mdx`. So CSS is the only route.

Mintlify auto-loads a root `style.css` — the same mechanism that already loads `reo.js` and `webinar-card.js`.

## Verification

Measured with Puppeteer against `mint dev`, both themes, across `/introduction/getting-started`, `/bru-cli/overview`, `/license-overview`, `/send-requests/REST/rest-api` and `/bru-cli/commandOptions`.

**Nothing lost in the restructure.** All 196 pages currently in the v4 nav are still there, each exactly once, every one resolving to a file. `v2` and `v3` navigation are byte-identical — they're legacy version snapshots and are deliberately untouched.

**Tab spacing** — gap spread is exactly `0.00px` at every width, i.e. all six gaps identical:

| viewport | each gap   | bar span   |                  |
| -------- | ---------- | ---------- | ---------------- |
| 1024     | 45.93px    | 48 → 976   | flush both edges |
| 1440     | 115.26px   | 48 → 1392  | flush both edges |
| 1920     | 120.59px\* | 272 → 1648 | flush both edges |

\* before the full-width change; 195.3px after, since the rail is no longer capped.

**Full width** — a measured no-op up to 1472px, so most