### PR TITLE
docs: product-based sidebar sections, and go full width (alternative to #161)

### DIFF
--- a/api-client/overview.mdx
+++ b/api-client/overview.mdx
@@ -1,0 +1,59 @@
+---
+title: "API Client"
+sidebarTitle: "Overview"
+---
+
+The Bruno API Client is the desktop app you use to build, send, and organize API requests. Collections are stored as plain text files on your filesystem, so you can version them with Git and review API changes like code.
+
+New to Bruno? Start with the [Bruno Starter Guide](/introduction/quick-start), or [download the app](/get-started/bruno-basics/download) if you haven't installed it yet.
+
+## What's in the API Client
+
+<CardGroup cols={2}>
+  <Card title="Send Requests" icon="paper-plane" href="/send-requests/overview">
+    Build and send REST, GraphQL, gRPC, WebSocket, and SOAP requests.
+  </Card>
+  <Card title="Variables" icon="brackets-curly" href="/variables/overview">
+    Reuse values across environments, collections, folders, and requests.
+  </Card>
+  <Card title="Authentication" icon="lock" href="/auth/overview">
+    Configure Basic, Bearer, OAuth 2.0, AWS Signature, and more.
+  </Card>
+  <Card title="Tests & Scripts" icon="code" href="/testing/tests/introduction">
+    Write assertions and pre-request or post-response scripts in JavaScript.
+  </Card>
+  <Card
+    title="Secret Management"
+    icon="key"
+    href="/secrets-management/overview"
+  >
+    Keep credentials out of version control with secret variables and vaults.
+  </Card>
+  <Card
+    title="Git & Collaboration"
+    icon="code-branch"
+    href="/git-integration/overview"
+  >
+    Share collections with your team through your existing Git workflow.
+  </Card>
+</CardGroup>
+
+## The rest of Bruno
+
+The API Client is one of four parts of Bruno. The others read the same collection files, so work you do in one carries over to the others.
+
+<CardGroup cols={3}>
+  <Card title="CLI" icon="terminal" href="/bru-cli/overview">
+    Run the same collections from the command line and in CI/CD.
+  </Card>
+  <Card title="API Docs" icon="book" href="/api-docs/overview">
+    Document your APIs and generate shareable documentation.
+  </Card>
+  <Card
+    title="VS Code Extension"
+    icon="code"
+    href="/vs-code-extension/overview"
+  >
+    Open and send requests without leaving your editor.
+  </Card>
+</CardGroup>

--- a/api-client/overview.mdx
+++ b/api-client/overview.mdx
@@ -19,7 +19,11 @@ New to Bruno? Start with the [Bruno Starter Guide](/introduction/quick-start), o
   <Card title="Authentication" icon="lock" href="/auth/overview">
     Configure Basic, Bearer, OAuth 2.0, AWS Signature, and more.
   </Card>
-  <Card title="Tests & Scripts" icon="code" href="/testing/tests/introduction">
+  <Card
+    title="Testing & Scripting"
+    icon="code"
+    href="/testing/tests/introduction"
+  >
     Write assertions and pre-request or post-response scripts in JavaScript.
   </Card>
   <Card

--- a/docs.json
+++ b/docs.json
@@ -107,17 +107,17 @@
                       "send-requests/soap/soap-request"
                     ]
                   },
-                  {
-                    "group": "Response Data & Cookies",
-                    "pages": [
-                      "send-requests/res-data-cookies/overview",
-                      "send-requests/res-data-cookies/res-data",
-                      "send-requests/res-data-cookies/cookies",
-                      "send-requests/res-data-cookies/response-examples",
-                      "advanced-guides/visualize"
-                    ]
-                  },
                   "send-requests/history"
+                ]
+              },
+              {
+                "group": "Responses & Cookies",
+                "pages": [
+                  "send-requests/res-data-cookies/overview",
+                  "send-requests/res-data-cookies/res-data",
+                  "send-requests/res-data-cookies/cookies",
+                  "send-requests/res-data-cookies/response-examples",
+                  "advanced-guides/visualize"
                 ]
               },
               {
@@ -205,43 +205,10 @@
                 ]
               },
               {
-                "group": "Tests & Scripts",
+                "group": "Testing",
                 "pages": [
-                  {
-                    "group": "Tests",
-                    "pages": [
-                      "testing/tests/introduction",
-                      "testing/tests/assertions"
-                    ]
-                  },
-                  {
-                    "group": "Scripts",
-                    "pages": [
-                      "testing/script/getting-started",
-                      "testing/script/javascript-reference",
-                      "testing/script/script-flow",
-                      "testing/script/inbuilt-libraries",
-                      "testing/script/external-libraries",
-                      "testing/script/js-file",
-                      "testing/script/dynamic-variables",
-                      "testing/script/request-chaining",
-                      {
-                        "group": "Request",
-                        "pages": [
-                          "testing/script/request/request-object",
-                          "testing/script/request/sync-requests"
-                        ]
-                      },
-                      {
-                        "group": "Response",
-                        "pages": [
-                          "testing/script/response/response-object",
-                          "testing/script/response/response-query"
-                        ]
-                      },
-                      "testing/script/vars"
-                    ]
-                  },
+                  "testing/tests/introduction",
+                  "testing/tests/assertions",
                   {
                     "group": "Automate Tests",
                     "pages": [
@@ -251,6 +218,34 @@
                       "testing/automate-test/data-driven-testing"
                     ]
                   }
+                ]
+              },
+              {
+                "group": "Scripting",
+                "pages": [
+                  "testing/script/getting-started",
+                  "testing/script/javascript-reference",
+                  "testing/script/script-flow",
+                  "testing/script/inbuilt-libraries",
+                  "testing/script/external-libraries",
+                  "testing/script/js-file",
+                  "testing/script/dynamic-variables",
+                  "testing/script/request-chaining",
+                  {
+                    "group": "Request",
+                    "pages": [
+                      "testing/script/request/request-object",
+                      "testing/script/request/sync-requests"
+                    ]
+                  },
+                  {
+                    "group": "Response",
+                    "pages": [
+                      "testing/script/response/response-object",
+                      "testing/script/response/response-query"
+                    ]
+                  },
+                  "testing/script/vars"
                 ]
               },
               {
@@ -267,17 +262,17 @@
                     ]
                   },
                   "git-integration/using-cli",
-                  "git-integration/gitlab",
-                  "git-integration/bitbucket",
-                  "git-integration/azure-devops",
-                  "git-integration/embed-bruno-collection",
                   {
-                    "group": "Git Providers",
+                    "group": "Providers",
                     "pages": [
                       "git-providers/overview",
-                      "git-providers/github"
+                      "git-providers/github",
+                      "git-integration/gitlab",
+                      "git-integration/bitbucket",
+                      "git-integration/azure-devops"
                     ]
-                  }
+                  },
+                  "git-integration/embed-bruno-collection"
                 ]
               },
               {
@@ -340,13 +335,8 @@
             "icon": "terminal",
             "pages": [
               "bru-cli/overview",
-              {
-                "group": "Install & Quick Start",
-                "pages": [
-                  "bru-cli/quick-start",
-                  "bru-cli/installation"
-                ]
-              },
+              "bru-cli/quick-start",
+              "bru-cli/installation",
               {
                 "group": "Run Collections",
                 "pages": [
@@ -455,12 +445,7 @@
             "icon": "key",
             "pages": [
               "license-overview",
-              {
-                "group": "End Users",
-                "pages": [
-                  "license-end-users/activate-license"
-                ]
-              },
+              "license-end-users/activate-license",
               {
                 "group": "Administrators",
                 "pages": [

--- a/docs.json
+++ b/docs.json
@@ -16,7 +16,7 @@
         "tag": "Latest",
         "groups": [
           {
-            "group": "Getting Started",
+            "group": "Get Started",
             "icon": "rocket",
             "pages": [
               {
@@ -41,7 +41,7 @@
                 ]
               },
               {
-                "group": "Import or Export Data",
+                "group": "Import & Migrate",
                 "pages": [
                   "get-started/import-export-data/import-collections",
                   "get-started/import-export-data/export-collections",
@@ -50,22 +50,14 @@
                   "get-started/import-export-data/postman-migration",
                   "get-started/import-export-data/script-translator"
                 ]
-              },
-              {
-                "group": "Configure",
-                "pages": [
-                  "get-started/configure/settings",
-                  "get-started/configure/keybindings",
-                  "get-started/configure/proxy-config",
-                  "get-started/configure/javascript-sandbox"
-                ]
               }
             ]
           },
           {
-            "group": "Core Features",
-            "icon": "zap",
+            "group": "API Client",
+            "icon": "window-maximize",
             "pages": [
+              "api-client/overview",
               {
                 "group": "Send Requests",
                 "pages": [
@@ -121,7 +113,8 @@
                       "send-requests/res-data-cookies/overview",
                       "send-requests/res-data-cookies/res-data",
                       "send-requests/res-data-cookies/cookies",
-                      "send-requests/res-data-cookies/response-examples"
+                      "send-requests/res-data-cookies/response-examples",
+                      "advanced-guides/visualize"
                     ]
                   },
                   "send-requests/history"
@@ -143,34 +136,76 @@
                 ]
               },
               {
-                "group": "Git Integration & Collaboration",
+                "group": "Authentication",
                 "pages": [
-                  "git-integration/overview",
-                  "git-integration/git-strategies",
+                  "auth/overview",
+                  "auth/basic",
+                  "auth/bearer",
+                  "auth/digest",
+                  "auth/aws-signature",
+                  "auth/ntlm",
+                  "auth/oauth1",
+                  "auth/akamai-edgegrid",
                   {
-                    "group": "Using GUI",
+                    "group": "OAuth 2.0",
                     "pages": [
-                      "git-integration/using-gui/intro",
-                      "git-integration/using-gui/provider",
-                      "git-integration/using-gui/consumer"
+                      "auth/oauth2-2.0/overview",
+                      "auth/oauth2-2.0/collection-level-configuration",
+                      "auth/oauth2-2.0/authorization-code",
+                      "auth/oauth2-2.0/client-credentials",
+                      "auth/oauth2-2.0/password-credentials",
+                      "auth/oauth2-2.0/system-browser"
                     ]
                   },
-                  "git-integration/using-cli",
-                  "git-integration/gitlab",
-                  "git-integration/bitbucket",
-                  "git-integration/azure-devops",
-                  "git-integration/embed-bruno-collection"
+                  "auth/add-and-manage-certs"
                 ]
               },
               {
-                "group": "Git Providers",
+                "group": "Secret Management",
                 "pages": [
-                  "git-providers/overview",
-                  "git-providers/github"
+                  "secrets-management/overview",
+                  "secrets-management/secret-variables",
+                  "secrets-management/secret-masking",
+                  "secrets-management/dotenv-file",
+                  {
+                    "group": "Secret Managers",
+                    "pages": [
+                      "secrets-management/secret-managers/overview",
+                      "secrets-management/secret-managers/migration",
+                      {
+                        "group": "HashiCorp Vault",
+                        "pages": [
+                          "secrets-management/secret-managers/hashicorp-vault/overview",
+                          "secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider",
+                          "secrets-management/secret-managers/hashicorp-vault/configuring-and-fetching-secrets",
+                          "secrets-management/secret-managers/hashicorp-vault/using-secrets"
+                        ]
+                      },
+                      {
+                        "group": "AWS Secrets Manager",
+                        "pages": [
+                          "secrets-management/secret-managers/aws-secrets-manager/overview",
+                          "secrets-management/secret-managers/aws-secrets-manager/adding-a-secret-provider",
+                          "secrets-management/secret-managers/aws-secrets-manager/configuring-and-fetching-secrets",
+                          "secrets-management/secret-managers/aws-secrets-manager/using-secrets"
+                        ]
+                      },
+                      {
+                        "group": "Azure Key Vault",
+                        "pages": [
+                          "secrets-management/secret-managers/azure-key-vault/overview",
+                          "secrets-management/secret-managers/azure-key-vault/adding-a-secret-provider",
+                          "secrets-management/secret-managers/azure-key-vault/configuring-and-fetching-secrets",
+                          "secrets-management/secret-managers/azure-key-vault/using-secrets",
+                          "secrets-management/secret-managers/azure-key-vault/cli-authentication"
+                        ]
+                      }
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Tests and Scripts",
+                "group": "Tests & Scripts",
                 "pages": [
                   {
                     "group": "Tests",
@@ -219,114 +254,32 @@
                 ]
               },
               {
-                "group": "Secret Management",
+                "group": "Git & Collaboration",
                 "pages": [
-                  "secrets-management/overview",
-                  "secrets-management/secret-variables",
-                  "secrets-management/secret-masking",
-                  "secrets-management/dotenv-file",
+                  "git-integration/overview",
+                  "git-integration/git-strategies",
                   {
-                    "group": "Secret Managers",
+                    "group": "Using GUI",
                     "pages": [
-                      "secrets-management/secret-managers/overview",
-                      "secrets-management/secret-managers/migration",
-                      {
-                        "group": "HashiCorp Vault",
-                        "pages": [
-                          "secrets-management/secret-managers/hashicorp-vault/overview",
-                          "secrets-management/secret-managers/hashicorp-vault/adding-a-secret-provider",
-                          "secrets-management/secret-managers/hashicorp-vault/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/hashicorp-vault/using-secrets"                        
-                        ]
-                      },
-                      {
-                        "group": "AWS Secrets Manager",
-                        "pages": [
-                          "secrets-management/secret-managers/aws-secrets-manager/overview",
-                          "secrets-management/secret-managers/aws-secrets-manager/adding-a-secret-provider",
-                          "secrets-management/secret-managers/aws-secrets-manager/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/aws-secrets-manager/using-secrets"
-                        ]
-                      },
-                      {
-                        "group": "Azure Key Vault",
-                        "pages": [
-                          "secrets-management/secret-managers/azure-key-vault/overview",
-                          "secrets-management/secret-managers/azure-key-vault/adding-a-secret-provider",
-                          "secrets-management/secret-managers/azure-key-vault/configuring-and-fetching-secrets",
-                          "secrets-management/secret-managers/azure-key-vault/using-secrets",
-                          "secrets-management/secret-managers/azure-key-vault/cli-authentication"
-                        ]
-                      }
+                      "git-integration/using-gui/intro",
+                      "git-integration/using-gui/provider",
+                      "git-integration/using-gui/consumer"
+                    ]
+                  },
+                  "git-integration/using-cli",
+                  "git-integration/gitlab",
+                  "git-integration/bitbucket",
+                  "git-integration/azure-devops",
+                  "git-integration/embed-bruno-collection",
+                  {
+                    "group": "Git Providers",
+                    "pages": [
+                      "git-providers/overview",
+                      "git-providers/github"
                     ]
                   }
                 ]
               },
-              {
-                "group": "Authentication & Authorization",
-                "pages": [
-                  "auth/overview",
-                  "auth/basic",
-                  "auth/bearer",
-                  "auth/digest",
-                  "auth/aws-signature",
-                  "auth/ntlm",
-                  "auth/oauth1",
-                  "auth/akamai-edgegrid",
-                  {
-                    "group": "OAuth 2.0",
-                    "pages": [
-                      "auth/oauth2-2.0/overview",
-                      "auth/oauth2-2.0/collection-level-configuration",
-                      "auth/oauth2-2.0/authorization-code",
-                      "auth/oauth2-2.0/client-credentials",
-                      "auth/oauth2-2.0/password-credentials",
-                      "auth/oauth2-2.0/system-browser"
-                    ]
-                  },
-                  "auth/add-and-manage-certs"
-                ]
-              },
-              {
-                "group": "Debugging",
-                "pages": [
-                  "debugging/timeline",
-                  "debugging/dev-tools"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "API Tools",
-            "icon": "book-open",
-            "pages": [
-              {
-                "group": "Create Documentation",
-                "pages": [
-                  "api-docs/overview",
-                  "api-docs/workspace-docs",
-                  "api-docs/collection-docs",
-                  "api-docs/folder-docs",
-                  "api-docs/request-docs",
-                  "api-docs/auto-generate-docs"
-                ]
-              },
-              {
-                "group": "OpenAPI",
-                "pages": [
-                  "open-api/overview",
-                  "open-api/importOAS",
-                  "open-api/exportOAS",
-                  "open-api/createOAS",
-                  "open-api/openapi-sync"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Developer Tools",
-            "icon": "code",
-            "pages": [
               {
                 "group": "AI",
                 "tag": "Beta",
@@ -365,17 +318,54 @@
                 ]
               },
               {
-                "group": "Bruno CLI",
+                "group": "Settings",
                 "pages": [
-                  "bru-cli/overview",
+                  "get-started/configure/settings",
+                  "get-started/configure/keybindings",
+                  "get-started/configure/proxy-config",
+                  "get-started/configure/javascript-sandbox"
+                ]
+              },
+              {
+                "group": "Debugging",
+                "pages": [
+                  "debugging/timeline",
+                  "debugging/dev-tools"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "CLI",
+            "icon": "terminal",
+            "pages": [
+              "bru-cli/overview",
+              {
+                "group": "Install & Quick Start",
+                "pages": [
                   "bru-cli/quick-start",
-                  "bru-cli/installation",
-                  "bru-cli/commandOptions",
+                  "bru-cli/installation"
+                ]
+              },
+              {
+                "group": "Run Collections",
+                "pages": [
                   "bru-cli/runCollection",
+                  "bru-cli/commandOptions",
                   "bru-cli/builtInReporters",
-                  "bru-cli/import",
+                  "bru-cli/import"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
                   "bru-cli/proxyConfiguration",
-                  "bru-cli/secret-managers",
+                  "bru-cli/secret-managers"
+                ]
+              },
+              {
+                "group": "CI/CD",
+                "pages": [
                   "bru-cli/docker",
                   {
                     "group": "GitHub Actions",
@@ -387,7 +377,49 @@
                   },
                   "bru-cli/jenkins"
                 ]
+              }
+            ]
+          },
+          {
+            "group": "API Docs",
+            "icon": "book",
+            "pages": [
+              "api-docs/overview",
+              {
+                "group": "Write Documentation",
+                "pages": [
+                  "api-docs/workspace-docs",
+                  "api-docs/collection-docs",
+                  "api-docs/folder-docs",
+                  "api-docs/request-docs",
+                  "api-docs/auto-generate-docs"
+                ]
               },
+              {
+                "group": "OpenAPI",
+                "pages": [
+                  "open-api/overview",
+                  "open-api/importOAS",
+                  "open-api/exportOAS",
+                  "open-api/createOAS",
+                  "open-api/openapi-sync"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "VS Code Extension",
+            "icon": "code",
+            "pages": [
+              "vs-code-extension/overview",
+              "vs-code-extension/install-config",
+              "vs-code-extension/send-req"
+            ]
+          },
+          {
+            "group": "Reference",
+            "icon": "book-open",
+            "pages": [
               {
                 "group": "Bru Lang",
                 "pages": [
@@ -415,19 +447,11 @@
                   "converters/openapi-to-bruno",
                   "converters/wsdl-to-bruno"
                 ]
-              },
-              {
-                "group": "VS Code Extension",
-                "pages": [
-                  "vs-code-extension/overview",
-                  "vs-code-extension/install-config",
-                  "vs-code-extension/send-req"
-                ]
               }
             ]
           },
           {
-            "group": "License Management",
+            "group": "Licensing",
             "icon": "key",
             "pages": [
               "license-overview",
@@ -438,7 +462,7 @@
                 ]
               },
               {
-                "group": "License Administrators",
+                "group": "Administrators",
                 "pages": [
                   "license-administrators/license-portal",
                   "license-administrators/billing",
@@ -464,13 +488,6 @@
                   "license-administrators/ai-policy"
                 ]
               }
-            ]
-          },
-          {
-            "group": "Advanced Guides",
-            "icon": "graduation-cap",
-            "pages": [
-              "advanced-guides/visualize"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -107,15 +107,15 @@
                       "send-requests/soap/soap-request"
                     ]
                   },
+                  "send-requests/res-data-cookies/cookies",
                   "send-requests/history"
                 ]
               },
               {
-                "group": "Responses & Cookies",
+                "group": "Response Data",
                 "pages": [
                   "send-requests/res-data-cookies/overview",
                   "send-requests/res-data-cookies/res-data",
-                  "send-requests/res-data-cookies/cookies",
                   "send-requests/res-data-cookies/response-examples",
                   "advanced-guides/visualize"
                 ]

--- a/introduction/getting-started.mdx
+++ b/introduction/getting-started.mdx
@@ -1,8 +1,36 @@
 ---
 title: "Getting Started"
+description: "Bruno is a Git-friendly, offline-first API client built for developers who want fast local workflows, plain-text collections, and better collaboration through Git."
 ---
 
-Bruno is a Git-friendly, offline-first API client built for developers who want fast local workflows, plain-text collections, and better collaboration through Git.
+## Core products
+
+Four products, one plain-text collection format — anything you build in one carries over to the others.
+
+<CardGroup cols={2}>
+  <Card title="API Client" icon="window-maximize" href="/api-client/overview">
+    Build, send, and organize API requests in the desktop app, with
+    environments, authentication, tests, and scripts.
+  </Card>
+  <Card title="CLI" icon="terminal" href="/bru-cli/overview">
+    Run collections from the command line, generate test reports, and automate
+    API checks in CI/CD.
+  </Card>
+  <Card title="API Docs" icon="book" href="/api-docs/overview">
+    Document your APIs in Markdown and auto-generate shareable API
+    documentation.
+  </Card>
+  <Card
+    title="VS Code Extension"
+    icon="code"
+    href="/vs-code-extension/overview"
+  >
+    Open collections, edit `.bru` files, and send requests without leaving your
+    editor.
+  </Card>
+</CardGroup>
+
+## Quick starts
 
 <CardGroup cols={2}>
   <Card
@@ -10,51 +38,34 @@ Bruno is a Git-friendly, offline-first API client built for developers who want 
     icon="rocket"
     href="/introduction/quick-start"
   >
-    Hands-on walkthrough: create collections, send requests, write tests, and collaborate with Git in the app.
+    Hands-on walkthrough: create collections, send requests, write tests, and
+    collaborate with Git in the app.
+  </Card>
+  <Card title="CLI Starter Guide" icon="terminal" href="/bru-cli/quick-start">
+    Hands-on walkthrough: install Bruno CLI, run collections, generate reports,
+    and integrate with CI/CD.
   </Card>
   <Card
-    title="CLI Starter Guide"
-    icon="terminal"
-    href="/bru-cli/quick-start"
-  >
-    Hands-on walkthrough: install Bruno CLI, run collections, generate reports, and integrate with CI/CD.
-  </Card>
-
-   <Card
     title="Migrating from Postman"
     icon="right-left"
     href="/get-started/import-export-data/postman-migration"
   >
     Import your Postman collections and environments into Bruno in minutes.
   </Card>
-  
 </CardGroup>
-
----
 
 ## Start with a task
 
 <CardGroup cols={2}>
-  <Card
-    title="Bruno CLI"
-    icon="terminal"
-    href="/bru-cli/overview"
-  >
-    Run collections from the command line and automate API workflows in CI.
-  </Card>
-  <Card
-    title="Scripting"
-    icon="code"
-    href="/testing/script/getting-started"
-  >
+  <Card title="Scripting" icon="code" href="/testing/script/getting-started">
     Add pre-request and post-response scripts to customize and test requests.
   </Card>
-  <Card
-    title="Variables"
-    icon="brackets-curly"
-    href="/variables/overview"
-  >
+  <Card title="Variables" icon="brackets-curly" href="/variables/overview">
     Use variables across requests, environments, and collections.
+  </Card>
+  <Card title="Authentication" icon="lock" href="/auth/overview">
+    Configure Basic, Bearer, OAuth 2.0, and other auth methods for your
+    requests.
   </Card>
 </CardGroup>
 
@@ -65,7 +76,11 @@ Want to see Bruno in action? [Bruno Public Collections](https://github.com/bruno
 ## Why Bruno?
 
 - **[Git-friendly collaboration](/git-integration/overview)** — store collections as files and review API changes like code.
-- **Offline-first by design** — work locally without requiring a cloud account.<sup>*</sup>
+- **Offline-first by design** — work locally without requiring a cloud account.<sup>\*</sup>
 - **Plain text collections** — store requests in YAML for readable, versionable collections.
 
-<sub>\* Bruno does not require an account to use. Your email is only used to issue a license key if you <a href="https://www.usebruno.com/pricing">purchase a license</a>.</sub>
+<sub>
+  \* Bruno does not require an account to use. Your email is only used to issue
+  a license key if you{" "}
+  <a href="https://www.usebruno.com/pricing">purchase a license</a>.
+</sub>

--- a/send-requests/res-data-cookies/overview.mdx
+++ b/send-requests/res-data-cookies/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Response Data and Cookies"
+title: "Response Data"
 sidebarTitle: "Overview"
 ---
 
@@ -23,7 +23,7 @@ You can also:
 
 ## Cookies
 
-Bruno shows the cookies associated with each request. Cookies are typically used for storing user sessions and personalized content.
+Bruno shows the cookies associated with each request. Cookies are typically used for storing user sessions and personalized content. See [Cookies](/send-requests/res-data-cookies/cookies) for adding and managing them.
 
 ## Debugging
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,67 @@
+/* ---------------------------------------------------------------------------
+   Full-width docs shell — release Mintlify's 1472px cap
+   ---------------------------------------------------------------------------
+   Mintlify centres the whole shell — sidebar, article and table of contents —
+   inside a `max-w-8xl` box (`.max-w-8xl{max-width:92rem}`, i.e. 1472px at a
+   16px root font size) with `mx-auto`. Past that width the box stops growing
+   and the remainder becomes equal dead margins on both sides, which is why the
+   docs look narrow on a large display.
+
+   Why CSS and not docs.json: there is no content-width option in the schema.
+   The only native escape hatches are per-page frontmatter `mode: "wide"` (drops
+   the table of contents) and `mode: "custom"` (drops the sidebar *and* the
+   TOC), and either would have to be pasted into every .mdx file.
+
+   Two divs carry the cap, and both must be released or the navbar would sit on
+   a different grid from the body:
+     1. `<div class="max-w-8xl mx-auto relative">` — the navbar rail (wordmark,
+        search, header links). Plain utility class, specificity (0,1,0).
+     2. The wrapper around #sidebar, #content-area and the TOC. Same 92rem, but
+        written through Mintlify's per-page `mode` peer variants
+        (`peer-[.is-not-custom]:peer-[.is-not-center]:max-w-8xl`), which
+        compiles to a ~(0,3,0) selector.
+   `[class*="max-w-8xl"]` matches both — the bare utility and the peer variant
+   share that substring — with no coupling to where either sits in the tree, so
+   a Mintlify DOM reshuffle cannot half-apply this. The selector is repeated for
+   (0,3,1) so it outranks carrier 2 on specificity alone; today that insurance
+   is unused, because Mintlify injects this file unlayered and last, and an
+   unlayered declaration already beats any @layer utilities rule.
+
+   No media query is needed: below the width where the cap binds, `max-width`
+   is not the constraint and the rule changes nothing. The cap is in rem, so it
+   binds wherever 92rem lands for the reader's root font size, and this rule
+   releases it exactly there. #content-area is the single flex-grow child of
+   carrier 2, so it absorbs the new width; the sidebar's and TOC's own fixed
+   widths are untouched.
+
+   Known tradeoffs, in the order they will be noticed:
+   - Line length grows with the viewport. Body copy sits near the comfortable
+     45-90 character range at today's cap and goes well past it on a 2560px or
+     wider display. This is the real cost of the change. If long measure becomes
+     the complaint, the dial is a `max-width` on `#content` — but capping the
+     text column alone gives the page two different right edges, which reads as
+     a misalignment bug, so expect that tradeoff.
+   - Card grids are the weakest spot. Mintlify's `.columns` container query tops
+     out at 2 tracks, so cards inflate instead of reflowing into more columns; a
+     3-card group on a very wide screen shows two huge cards and an orphan.
+   - Images never upscale (Mintlify computes them to `width:auto` +
+     `max-width:100%`), so wide screenshots render at natural width and leave a
+     trailing gutter rather than stretching.
+   - Narrow tables and short code blocks span the full column and leave a wide
+     trailing gutter. Offsetting win: code blocks that used to scroll
+     horizontally now fit.
+
+   Maintenance couplings:
+   - `max-w-8xl` is a Mintlify-emitted Tailwind class, not a public API. If it
+     is renamed or replaced this rule silently stops matching and the layout
+     reverts to today's capped, centred shell — a safe failure direction, but
+     worth re-checking after a Mintlify bump.
+   - Conversely, any future Mintlify div carrying an 8xl cap is uncapped too.
+     There are exactly two today. No .mdx in this repo sets frontmatter `mode`,
+     so every page renders is-not-custom / is-not-center / is-not-wide /
+     is-not-frame; there is no second layout variant to check.
+   --------------------------------------------------------------------------- */
+
+div[class*="max-w-8xl"][class*="max-w-8xl"][class*="max-w-8xl"] {
+  max-width: none;
+}


### PR DESCRIPTION
> Supersedes #162 — identical content, reopened from an in-repo branch so the Mintlify preview deployment builds.

## Why

Same feedback as #161: the docs are hard to navigate — it isn't easy to find what you need from the sidebar, and it isn't easy to tell what the different parts of Bruno actually are. The v4 sidebar was a single flat list of six generic buckets (Getting Started, Core Features, API Tools, Developer Tools, License Management, Advanced Guides) that mixed the products together.

**This PR is the sidebar alternative to #161.** Same product taxonomy, different presentation: instead of Mintlify header tabs, the products are top-level sidebar sections, so every product stays visible in one scrollable sidebar and nothing hides behind a tab switch. It also goes further than #161 on the second level, flattening the groups inside each section (details below). Review both and keep one. (#160 is a third, independent exploration of the same feedback.)

## What changed

**1. Sidebar restructured around Bruno's products** (`docs.json`)

The six buckets are replaced with one top-level sidebar section per product, plus three sections for content that doesn't belong to a single product:

`Get Started` | `API Client` | `CLI` | `API Docs` | `VS Code Extension` | `Reference` | `Licensing`

The four product sections are the spine. **Get Started** is the cross-product onboarding path, **Reference** holds the genuinely shared material (Bru Lang, OpenCollection YAML, converters), and **Licensing** is orthogonal to all four. Mintlify renders each top-level group as a section header with its icon, with the groups inside it collapsing.

Moves shared with #161:

- **CLI** is promoted from a subgroup to a top-level section (it was a 10-item flat list under "Developer Tools").
- `advanced-guides/visualize` moves under response data, retiring the one-page "Advanced Guides" group.
- `get-started/configure/*` becomes "Settings" under API Client.

Re-cuts specific to this PR — the section header already spends one sidebar level, so umbrella groups and single-page accordions were pushing real content three and four expandable levels down:

- **"Send Requests" splits in two**: "Send Requests" (protocols, cookies, history) and "Response Data" (response data, response examples, visualize). Every response page gets one level shallower.
- **"Tests & Scripts" splits into "Testing" and "Scripting"**. Script pages sat four levels deep (API Client → Tests & Scripts → Scripts → Request → page); the umbrella added a level without adding meaning.
- **Cookies moves under Send Requests.** The page opens with "add, send, view, and delete *request* cookies" and is almost entirely about configuring outgoing cookies and CLI cookie forwarding — it's request-side content.
- **Git provider pages unify.** `gitlab`, `bitbucket`, and `azure-devops` sat loose while `github` hid inside a "Git Providers" subgroup — the same kind of content at two different levels. All five now live in one "Providers" subgroup under "Git & Collaboration".
- **Thin accordions removed.** Licensing's one-page "End Users" group is gone (`activate-license` is a loose page), and the CLI's entry path (`overview`, `quick-start`, `installation`) sits loose above its topic groups instead of behind a two-page "Install & Quick Start" accordion.

**2. New landing pages** (`api-client/overview.mdx`, `introduction/getting-started.mdx`)

- `api-client/overview.mdx` (new) gives the API Client section a landing page and cross-links the other three products.
- The Getting Started page now leads with a "Core products" card grid — the four products, each with a one-line description and a link to its section, using the same icons as the sidebar. Its old intro paragraph became `description` frontmatter (renders as the page subtitle), and the duplicate "Bruno CLI" task card was replaced with "Authentication".

**3. The docs shell is full width** (`style.css`, new file)

Mintlify centres the whole shell inside a `max-w-8xl` (92rem / 1472px) box, leaving the rest of a wide viewport as dead margins. Two elements carry that cap — the navbar rail and the wrapper around the sidebar/content/TOC — and both are released; releasing only one would put the navbar on a different grid from the body. `docs.json` has no content-width option, and the native escape hatches (per-page frontmatter `mode: "wide"` / `"custom"`) drop chrome we want to keep. Mintlify auto-injects a root `style.css`, the same mechanism that already loads `reo.js` and `webinar-card.js`. Unlike #161, no tab-row CSS is needed — there is no tab row.

**No files were moved and no page paths changed**, so every existing URL still resolves and no redirects are needed. (`send-requests/res-data-cookies/` is a filesystem detail, not a nav constraint.)

## Verification

- **Nothing lost.** All 196 pages in the current `main` v4 nav are present, each exactly once, plus the new `api-client/overview` (197 total). Checked mechanically by a generator script that diffs the nav inventory against `main` and refuses to write on any mismatch.
- `mint validate` passes; `mint broken-links` output is **byte-identical** to `main` (the same 62 pre-existing broken links in 38 files — none new, measured on a clean worktree of `main` with the same mint version).
- Rendered against `mint dev`: all seven sections appear as sidebar headers with their icons, the new group labels render, the old ones appear only in the untouched v3 legacy nav, and both `max-w-8xl` carriers match the CSS.
- Every icon resolves on Mintlify's Font Awesome CDN. Note for #161: `app-window` is a Lucide name and 403s on that CDN — this PR uses `window-maximize` for the API Client icon.
- `v2` and `v3` navigation are byte-identical to `main` — legacy version snapshots, deliberately untouched.
- Current `main` (the SSE docs, #156) is merged in, with the SSE page slotted into the REST group at its upstream position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
